### PR TITLE
Clean before building examples on CI

### DIFF
--- a/ci/scripts/build_all_examples.sh
+++ b/ci/scripts/build_all_examples.sh
@@ -23,6 +23,7 @@ function build_all_configs() {
     local build_summary_file=$7
     local board_filter=$8
     local sd_variant_filter=$9
+    local flags="${10}"
 
     if [[ ! -d $config_dir ]]; then
         echo "\"$config_dir\" is not a valid configuration directory"
@@ -63,7 +64,7 @@ function build_all_configs() {
             local start_ts=`date +%s%N`
 
             local build_status
-            build_example "$example" "$sdk_version" "$board" "$sd_variant" "$toolchain" "$config_dir" "$build_dir" "$log_level"
+            build_example "$example" "$sdk_version" "$board" "$sd_variant" "$toolchain" "$config_dir" "$build_dir" "$log_level" "${flags[*]}"
             [[ $? -eq 0 ]] && build_status="success" || build_status="failure" 
 
             local end_ts=`date +%s%N`
@@ -101,6 +102,10 @@ function print_help() {
         --log_level=<log_level>     CMake log level. Will be passed as '--log-level' option
                                     when invoking CMake. Available log levels: TRACE, DEBUG,
                                     VERBOSE, STATUS, NOTICE, WARNING, ERROR.
+
+        --clean                     Invoke build system 'Clean' command before building
+                                    each example.
+
     "
     exit 0
 }
@@ -110,6 +115,7 @@ board_filter=""
 sd_variant_filter=""
 sdk_version_list=""
 log_level="NOTICE"
+flags=()
 
 while getopts ":h-:" opt; do
     case $opt in
@@ -131,6 +137,8 @@ while getopts ":h-:" opt; do
                         exit 1
                     fi
                 };;
+                clean)
+                    flags+=('clean') ;;
                 help)
                     print_help ;;
                 *) {
@@ -212,11 +220,11 @@ for sdk_ver in "${sdk_versions[@]}"; do
     for example in "${example_local_dirs[@]}"; do
         # Build all custom configs in the local example directory
         if [[ -d "$EXAMPLES_DIR/$example/config" ]]; then
-            build_all_configs "$example" "$sdk_ver" "gcc" "$EXAMPLES_DIR/$example/config" "$BUILD_DIR/local" "$log_level" "$build_summary_file" "$board_filter" "$sd_variant_filter"
+            build_all_configs "$example" "$sdk_ver" "gcc" "$EXAMPLES_DIR/$example/config" "$BUILD_DIR/local" "$log_level" "$build_summary_file" "$board_filter" "$sd_variant_filter" "${flags[*]}"
         fi
 
         # Build all configs in the SDK example directory
-        build_all_configs "$example" "$sdk_ver" "gcc" "$SDKS_DIR/$sdk_ver/examples/$example" "$BUILD_DIR" "$log_level" "$build_summary_file" "$board_filter" "$sd_variant_filter"
+        build_all_configs "$example" "$sdk_ver" "gcc" "$SDKS_DIR/$sdk_ver/examples/$example" "$BUILD_DIR" "$log_level" "$build_summary_file" "$board_filter" "$sd_variant_filter" "${flags[*]}"
     done
 done
 

--- a/ci/scripts/build_example.sh
+++ b/ci/scripts/build_example.sh
@@ -33,6 +33,9 @@ function print_help() {
         --log_level=<log_level>     CMake log level. Will be passed as '--log-level' option
                                     when invoking CMake. Available log levels: TRACE, DEBUG,
                                     VERBOSE, STATUS, NOTICE, WARNING, ERROR.
+        
+        --clean                     Invoke build system 'Clean' command before commencing build.
+
     "
     exit 0
 }
@@ -51,6 +54,7 @@ sd_variant=""
 toolchain="gcc"
 config_dir=""
 log_level="STATUS"
+flags=()
 
 while getopts ":h-:" opt; do
     case $opt in
@@ -78,6 +82,8 @@ while getopts ":h-:" opt; do
                         exit 1
                     fi
                 };;
+                clean)
+                    flags+=('clean') ;;
                 help)
                     print_help ;;
                 *) {
@@ -106,4 +112,4 @@ check_option "sdk_version" $sdk_version
 check_option "board" $board
 check_option "sd_variant" $sd_variant
 
-build_example "$example" "$sdk_version" "$board" "$sd_variant" "$toolchain" "$config_dir" "$build_dir" "$log_level"
+build_example "$example" "$sdk_version" "$board" "$sd_variant" "$toolchain" "$config_dir" "$build_dir" "$log_level" "${flags[*]}"

--- a/ci/scripts/common/build_example.sh
+++ b/ci/scripts/common/build_example.sh
@@ -32,6 +32,7 @@ function build_example() {
         echo "6) configuration directory (optional)"
         echo "7) build directory (optional)"
         echo "8) CMake log level (optional), e.g.: STATUS, WARNING, FATAL_ERROR"
+        echo "9) flags (optional), e.g. clean"
         return 1
     fi
 
@@ -43,6 +44,7 @@ function build_example() {
     local config_dir=$6
     local build_dir=$7
     local log_level=$8
+    local flags=$9
 
     local repo_example_dir="$EXAMPLES_DIR/$example_local_dir"
     local sdk_example_dir="$SDKS_DIR/$sdk_version/examples/$example_local_dir"
@@ -158,6 +160,10 @@ function build_example() {
 
     # Move to the build directory
     pushd "$cmake_build_path" > /dev/null
+        if [[ "${flags[@]}" =~ [[:\<:]]clean[[:\>:]] ]]; then
+            $build_cmd clean
+        fi
+
         $build_cmd || {
             echo "Failed to build with ninja"
             popd > /dev/null

--- a/ci/scripts/common/build_example.sh
+++ b/ci/scripts/common/build_example.sh
@@ -165,7 +165,7 @@ function build_example() {
         fi
 
         $build_cmd || {
-            echo "Failed to build with ninja"
+            echo "Failed to build with $build_type"
             popd > /dev/null
             return 1
         }


### PR DESCRIPTION
This PR adds `--clean` option to `ci/build_example.sh` and `ci/build_all_examples.sh` scripts. When passed, the 'Clean' command of the build system (presumably Ninja or make) will be invoked before an example is built.