### PR TITLE
Add more ble_peripheral examples

### DIFF
--- a/ci/examples/ble_peripheral/ble_app_alert_notification/CMakeLists.txt
+++ b/ci/examples/ble_peripheral/ble_app_alert_notification/CMakeLists.txt
@@ -1,0 +1,98 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.14)
+project(ble_app_alert_notification LANGUAGES C ASM)
+
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME}
+  "${NRF5_SDK_PATH}/examples/ble_peripheral/ble_app_alert_notification/main.c"
+)
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+  nrf5_app_button
+  nrf5_app_error
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_assert
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_ble_advertising
+  nrf5_ble_auth_status_tracker
+  nrf5_ble_common
+  nrf5_ble_db_discovery
+  nrf5_ble_gatt
+  nrf5_ble_gatt_cache_manager
+  nrf5_ble_id_manager
+  nrf5_ble_peer_data_storage
+  nrf5_ble_peer_database
+  nrf5_ble_peer_id
+  nrf5_ble_peer_manager
+  nrf5_ble_peer_manager_handler
+  nrf5_ble_pm_buffer
+  nrf5_ble_qwr
+  nrf5_ble_security_dispatcher
+  nrf5_ble_security_manager
+  nrf5_ble_srv_ans_c
+  nrf5_boards
+  nrf5_bsp
+  nrf5_bsp_btn_ble
+  nrf5_crc16
+  nrf5_drv_clock
+  nrf5_drv_uart
+  nrf5_ext_fprintf
+  nrf5_ext_segger_rtt
+  nrf5_ext_utf_converter
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_fstorage_sd
+  nrf5_hardfault
+  nrf5_log
+  nrf5_log_backend_rtt
+  nrf5_log_backend_serial
+  nrf5_log_backend_uart
+  nrf5_log_default_backends
+  nrf5_mdk
+  nrf5_memobj
+  nrf5_nrfx_clock
+  nrf5_nrfx_gpiote
+  nrf5_nrfx_prs
+  nrf5_nrfx_soc
+  nrf5_nrfx_uart
+  nrf5_nrfx_uarte
+  nrf5_pwr_mgmt
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_sortlist
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+    nrf5_ble_gq
+    nrf5_queue
+  )
+endif()

--- a/ci/examples/ble_peripheral/ble_app_bps/CMakeLists.txt
+++ b/ci/examples/ble_peripheral/ble_app_bps/CMakeLists.txt
@@ -1,0 +1,100 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.14)
+project(ble_app_bps LANGUAGES C ASM)
+
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME}
+  "${NRF5_SDK_PATH}/examples/ble_peripheral/ble_app_bps/main.c"
+)
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+  nrf5_app_button
+  nrf5_app_error
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_assert
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_ble_advertising
+  nrf5_ble_auth_status_tracker
+  nrf5_ble_common
+  nrf5_ble_gatt
+  nrf5_ble_gatt_cache_manager
+  nrf5_ble_id_manager
+  nrf5_ble_peer_data_storage
+  nrf5_ble_peer_database
+  nrf5_ble_peer_id
+  nrf5_ble_peer_manager
+  nrf5_ble_peer_manager_handler
+  nrf5_ble_pm_buffer
+  nrf5_ble_qwr
+  nrf5_ble_security_dispatcher
+  nrf5_ble_security_manager
+  nrf5_ble_srv_bas
+  nrf5_ble_srv_dis
+  nrf5_ble_srv_bps
+  nrf5_boards
+  nrf5_bsp
+  nrf5_bsp_btn_ble
+  nrf5_crc16
+  nrf5_drv_clock
+  nrf5_drv_uart
+  nrf5_ext_fprintf
+  nrf5_ext_segger_rtt
+  nrf5_ext_utf_converter
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_fstorage_sd
+  nrf5_hardfault
+  nrf5_log
+  nrf5_log_backend_rtt
+  nrf5_log_backend_serial
+  nrf5_log_backend_uart
+  nrf5_log_default_backends
+  nrf5_mdk
+  nrf5_memobj
+  nrf5_nrfx_clock
+  nrf5_nrfx_gpiote
+  nrf5_nrfx_prs
+  nrf5_nrfx_soc
+  nrf5_nrfx_uart
+  nrf5_nrfx_uarte
+  nrf5_pwr_mgmt
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_sensorsim
+  nrf5_sortlist
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+    nrf5_ble_gq
+    nrf5_queue
+  )
+endif()

--- a/ci/examples/ble_peripheral/ble_app_cscs/CMakeLists.txt
+++ b/ci/examples/ble_peripheral/ble_app_cscs/CMakeLists.txt
@@ -1,0 +1,94 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.14)
+project(ble_app_cscs LANGUAGES C ASM)
+
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME}
+  "${NRF5_SDK_PATH}/examples/ble_peripheral/ble_app_cscs/main.c"
+)
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+  nrf5_app_button
+  nrf5_app_error
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_assert
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_ble_advertising
+  nrf5_ble_auth_status_tracker
+  nrf5_ble_common
+  nrf5_ble_gatt
+  nrf5_ble_gatt_cache_manager
+  nrf5_ble_id_manager
+  nrf5_ble_peer_data_storage
+  nrf5_ble_peer_database
+  nrf5_ble_peer_id
+  nrf5_ble_peer_manager
+  nrf5_ble_peer_manager_handler
+  nrf5_ble_pm_buffer
+  nrf5_ble_qwr
+  nrf5_ble_security_dispatcher
+  nrf5_ble_security_manager
+  nrf5_ble_srv_bas
+  nrf5_ble_srv_dis
+  nrf5_ble_srv_cscs
+  nrf5_boards
+  nrf5_bsp
+  nrf5_bsp_btn_ble
+  nrf5_crc16
+  nrf5_drv_clock
+  nrf5_drv_uart
+  nrf5_ext_fprintf
+  nrf5_ext_segger_rtt
+  nrf5_ext_utf_converter
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_fstorage_sd
+  nrf5_hardfault
+  nrf5_log
+  nrf5_log_backend_rtt
+  nrf5_log_backend_serial
+  nrf5_log_backend_uart
+  nrf5_log_default_backends
+  nrf5_mdk
+  nrf5_memobj
+  nrf5_nrfx_clock
+  nrf5_nrfx_gpiote
+  nrf5_nrfx_prs
+  nrf5_nrfx_soc
+  nrf5_nrfx_uart
+  nrf5_nrfx_uarte
+  nrf5_pwr_mgmt
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_sensorsim
+  nrf5_sortlist
+  nrf5_strerror
+)

--- a/ci/examples/ble_peripheral/ble_app_cts_c/CMakeLists.txt
+++ b/ci/examples/ble_peripheral/ble_app_cts_c/CMakeLists.txt
@@ -1,0 +1,98 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.14)
+project(ble_app_cts_c LANGUAGES C ASM)
+
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME}
+  "${NRF5_SDK_PATH}/examples/ble_peripheral/ble_app_cts_c/main.c"
+)
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+  nrf5_app_button
+  nrf5_app_error
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_assert
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_ble_advertising
+  nrf5_ble_auth_status_tracker
+  nrf5_ble_common
+  nrf5_ble_db_discovery
+  nrf5_ble_gatt
+  nrf5_ble_gatt_cache_manager
+  nrf5_ble_id_manager
+  nrf5_ble_peer_data_storage
+  nrf5_ble_peer_database
+  nrf5_ble_peer_id
+  nrf5_ble_peer_manager
+  nrf5_ble_peer_manager_handler
+  nrf5_ble_pm_buffer
+  nrf5_ble_qwr
+  nrf5_ble_security_dispatcher
+  nrf5_ble_security_manager
+  nrf5_ble_srv_cts_c
+  nrf5_boards
+  nrf5_bsp
+  nrf5_bsp_btn_ble
+  nrf5_crc16
+  nrf5_drv_clock
+  nrf5_drv_uart
+  nrf5_ext_fprintf
+  nrf5_ext_segger_rtt
+  nrf5_ext_utf_converter
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_fstorage_sd
+  nrf5_hardfault
+  nrf5_log
+  nrf5_log_backend_rtt
+  nrf5_log_backend_serial
+  nrf5_log_backend_uart
+  nrf5_log_default_backends
+  nrf5_mdk
+  nrf5_memobj
+  nrf5_nrfx_clock
+  nrf5_nrfx_gpiote
+  nrf5_nrfx_prs
+  nrf5_nrfx_soc
+  nrf5_nrfx_uart
+  nrf5_nrfx_uarte
+  nrf5_pwr_mgmt
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_sortlist
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+    nrf5_ble_gq
+    nrf5_queue
+  )
+endif()

--- a/ci/examples/ble_peripheral/ble_app_gatts_c/CMakeLists.txt
+++ b/ci/examples/ble_peripheral/ble_app_gatts_c/CMakeLists.txt
@@ -1,0 +1,103 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.14)
+project(ble_app_gatts_c LANGUAGES C ASM)
+
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME}
+  "${NRF5_SDK_PATH}/examples/ble_peripheral/ble_app_gatts_c/main.c"
+  "${NRF5_SDK_PATH}/examples/ble_peripheral/ble_app_gatts_c/app_bsp.c"
+  "${NRF5_SDK_PATH}/examples/ble_peripheral/ble_app_gatts_c/app_adv.c"
+)
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
+  "."
+)
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+  nrf5_app_button
+  nrf5_app_error
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_assert
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_ble_advertising
+  nrf5_ble_auth_status_tracker
+  nrf5_ble_common
+  nrf5_ble_db_discovery
+  nrf5_ble_gatt
+  nrf5_ble_gatt_cache_manager
+  nrf5_ble_id_manager
+  nrf5_ble_peer_data_storage
+  nrf5_ble_peer_database
+  nrf5_ble_peer_id
+  nrf5_ble_peer_manager
+  nrf5_ble_peer_manager_handler
+  nrf5_ble_pm_buffer
+  nrf5_ble_qwr
+  nrf5_ble_security_dispatcher
+  nrf5_ble_security_manager
+  nrf5_ble_srv_gatts_c
+  nrf5_boards
+  nrf5_bsp
+  nrf5_bsp_btn_ble
+  nrf5_crc16
+  nrf5_drv_clock
+  nrf5_drv_uart
+  nrf5_ext_fprintf
+  nrf5_ext_segger_rtt
+  nrf5_ext_utf_converter
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_fstorage_sd
+  nrf5_hardfault
+  nrf5_log
+  nrf5_log_backend_rtt
+  nrf5_log_backend_serial
+  nrf5_log_backend_uart
+  nrf5_log_default_backends
+  nrf5_mdk
+  nrf5_memobj
+  nrf5_nrfx_clock
+  nrf5_nrfx_gpiote
+  nrf5_nrfx_prs
+  nrf5_nrfx_soc
+  nrf5_nrfx_uart
+  nrf5_nrfx_uarte
+  nrf5_pwr_mgmt
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_sortlist
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+    nrf5_ble_gq
+    nrf5_queue
+  )
+endif()

--- a/ci/examples/ble_peripheral/ble_app_gatts_c/fstorage.h
+++ b/ci/examples/ble_peripheral/ble_app_gatts_c/fstorage.h
@@ -1,0 +1,1 @@
+/* This file seems to be missing in the SDK. */

--- a/ci/examples/ble_peripheral/ble_app_gatts_c/softdevice_handler.h
+++ b/ci/examples/ble_peripheral/ble_app_gatts_c/softdevice_handler.h
@@ -1,0 +1,1 @@
+/* This file seems to be missing in the SDK. */

--- a/ci/examples/ble_peripheral/ble_app_hids_keyboard/CMakeLists.txt
+++ b/ci/examples/ble_peripheral/ble_app_hids_keyboard/CMakeLists.txt
@@ -1,0 +1,95 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.14)
+project(ble_app_hids_keyboard LANGUAGES C ASM)
+
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME}
+  "${NRF5_SDK_PATH}/examples/ble_peripheral/ble_app_hids_keyboard/main.c"
+)
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+  nrf5_app_button
+  nrf5_app_error
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_assert
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_ble_advertising
+  nrf5_ble_auth_status_tracker
+  nrf5_ble_common
+  nrf5_ble_gatt
+  nrf5_ble_gatt_cache_manager
+  nrf5_ble_id_manager
+  nrf5_ble_link_ctx_manager
+  nrf5_ble_peer_data_storage
+  nrf5_ble_peer_database
+  nrf5_ble_peer_id
+  nrf5_ble_peer_manager
+  nrf5_ble_peer_manager_handler
+  nrf5_ble_pm_buffer
+  nrf5_ble_qwr
+  nrf5_ble_security_dispatcher
+  nrf5_ble_security_manager
+  nrf5_ble_srv_bas
+  nrf5_ble_srv_dis
+  nrf5_ble_srv_hids
+  nrf5_boards
+  nrf5_bsp
+  nrf5_bsp_btn_ble
+  nrf5_crc16
+  nrf5_drv_clock
+  nrf5_drv_uart
+  nrf5_ext_fprintf
+  nrf5_ext_segger_rtt
+  nrf5_ext_utf_converter
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_fstorage_sd
+  nrf5_hardfault
+  nrf5_log
+  nrf5_log_backend_rtt
+  nrf5_log_backend_serial
+  nrf5_log_backend_uart
+  nrf5_log_default_backends
+  nrf5_mdk
+  nrf5_memobj
+  nrf5_nrfx_clock
+  nrf5_nrfx_gpiote
+  nrf5_nrfx_prs
+  nrf5_nrfx_soc
+  nrf5_nrfx_uart
+  nrf5_nrfx_uarte
+  nrf5_pwr_mgmt
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_sensorsim
+  nrf5_sortlist
+  nrf5_strerror
+)

--- a/ci/examples/ble_peripheral/ble_app_hids_mouse/CMakeLists.txt
+++ b/ci/examples/ble_peripheral/ble_app_hids_mouse/CMakeLists.txt
@@ -19,46 +19,77 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-#
-# WARNING: FILE GENERATED FROM ./ci/scripts/generate_cmake_tests.sh SCRIPT.
 
 cmake_minimum_required(VERSION 3.14)
-project(nrf5_drv_clock_test LANGUAGES C ASM)
+project(ble_app_hids_mouse LANGUAGES C ASM)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../../cmake")
 include("nrf5")
 
-add_executable(${CMAKE_PROJECT_NAME} "main.c")
+add_executable(${CMAKE_PROJECT_NAME}
+  "${NRF5_SDK_PATH}/examples/ble_peripheral/ble_app_hids_mouse/main.c"
+)
 nrf5_target(${CMAKE_PROJECT_NAME})
-target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+  nrf5_app_button
+  nrf5_app_error
   nrf5_app_scheduler
+  nrf5_app_timer
   nrf5_app_util_platform
+  nrf5_assert
   nrf5_atfifo
+  nrf5_atflags
   nrf5_atomic
   nrf5_balloc
-  nrf5_balloc_fwd
-  nrf5_cli
-  nrf5_cli_fwd
-  nrf5_config
-  nrf5_delay
+  nrf5_ble_advertising
+  nrf5_ble_auth_status_tracker
+  nrf5_ble_common
+  nrf5_ble_gatt
+  nrf5_ble_gatt_cache_manager
+  nrf5_ble_id_manager
+  nrf5_ble_link_ctx_manager
+  nrf5_ble_peer_data_storage
+  nrf5_ble_peer_database
+  nrf5_ble_peer_id
+  nrf5_ble_peer_manager
+  nrf5_ble_peer_manager_handler
+  nrf5_ble_pm_buffer
+  nrf5_ble_qwr
+  nrf5_ble_security_dispatcher
+  nrf5_ble_security_manager
+  nrf5_ble_srv_bas
+  nrf5_ble_srv_dis
+  nrf5_ble_srv_hids
+  nrf5_boards
+  nrf5_bsp
+  nrf5_bsp_btn_ble
+  nrf5_crc16
   nrf5_drv_clock
+  nrf5_drv_uart
   nrf5_ext_fprintf
+  nrf5_ext_segger_rtt
+  nrf5_ext_utf_converter
   nrf5_fds
   nrf5_fstorage
+  nrf5_fstorage_sd
+  nrf5_hardfault
   nrf5_log
-  nrf5_log_fwd
+  nrf5_log_backend_rtt
+  nrf5_log_backend_serial
+  nrf5_log_backend_uart
+  nrf5_log_default_backends
   nrf5_mdk
   nrf5_memobj
-  nrf5_memobj_fwd
-  nrf5_mtx
   nrf5_nrfx_clock
-  nrf5_nrfx_common
-  nrf5_nrfx_hal
+  nrf5_nrfx_gpiote
+  nrf5_nrfx_prs
+  nrf5_nrfx_soc
+  nrf5_nrfx_uart
+  nrf5_nrfx_uarte
   nrf5_pwr_mgmt
-  nrf5_queue
   nrf5_ringbuf
   nrf5_sdh
   nrf5_section
-  nrf5_soc
+  nrf5_sensorsim
+  nrf5_sortlist
   nrf5_strerror
 )

--- a/ci/examples/ble_peripheral/ble_app_hts/CMakeLists.txt
+++ b/ci/examples/ble_peripheral/ble_app_hts/CMakeLists.txt
@@ -1,0 +1,100 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.14)
+project(ble_app_hts LANGUAGES C ASM)
+
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME}
+  "${NRF5_SDK_PATH}/examples/ble_peripheral/ble_app_hts/main.c"
+)
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+  nrf5_app_button
+  nrf5_app_error
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_assert
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_ble_advertising
+  nrf5_ble_auth_status_tracker
+  nrf5_ble_common
+  nrf5_ble_gatt
+  nrf5_ble_gatt_cache_manager
+  nrf5_ble_id_manager
+  nrf5_ble_peer_data_storage
+  nrf5_ble_peer_database
+  nrf5_ble_peer_id
+  nrf5_ble_peer_manager
+  nrf5_ble_peer_manager_handler
+  nrf5_ble_pm_buffer
+  nrf5_ble_qwr
+  nrf5_ble_security_dispatcher
+  nrf5_ble_security_manager
+  nrf5_ble_srv_bas
+  nrf5_ble_srv_dis
+  nrf5_ble_srv_hts
+  nrf5_boards
+  nrf5_bsp
+  nrf5_bsp_btn_ble
+  nrf5_crc16
+  nrf5_drv_clock
+  nrf5_drv_uart
+  nrf5_ext_fprintf
+  nrf5_ext_segger_rtt
+  nrf5_ext_utf_converter
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_fstorage_sd
+  nrf5_hardfault
+  nrf5_log
+  nrf5_log_backend_rtt
+  nrf5_log_backend_serial
+  nrf5_log_backend_uart
+  nrf5_log_default_backends
+  nrf5_mdk
+  nrf5_memobj
+  nrf5_nrfx_clock
+  nrf5_nrfx_gpiote
+  nrf5_nrfx_prs
+  nrf5_nrfx_soc
+  nrf5_nrfx_uart
+  nrf5_nrfx_uarte
+  nrf5_pwr_mgmt
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_sensorsim
+  nrf5_sortlist
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+    nrf5_ble_gq
+    nrf5_queue
+  )
+endif()

--- a/ci/examples/ble_peripheral/ble_app_rscs/CMakeLists.txt
+++ b/ci/examples/ble_peripheral/ble_app_rscs/CMakeLists.txt
@@ -1,0 +1,95 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.14)
+project(ble_app_rscs LANGUAGES C ASM)
+
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME}
+  "${NRF5_SDK_PATH}/examples/ble_peripheral/ble_app_rscs/main.c"
+)
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+  nrf5_app_button
+  nrf5_app_error
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_assert
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_ble_advertising
+  nrf5_ble_auth_status_tracker
+  nrf5_ble_common
+  nrf5_ble_gatt
+  nrf5_ble_gatt_cache_manager
+  nrf5_ble_id_manager
+  nrf5_ble_peer_data_storage
+  nrf5_ble_peer_database
+  nrf5_ble_peer_id
+  nrf5_ble_peer_manager
+  nrf5_ble_peer_manager_handler
+  nrf5_ble_pm_buffer
+  nrf5_ble_qwr
+  nrf5_ble_security_dispatcher
+  nrf5_ble_security_manager
+  nrf5_ble_srv_bas
+  nrf5_ble_srv_dis
+  nrf5_ble_srv_hids
+  nrf5_ble_srv_rscs
+  nrf5_boards
+  nrf5_bsp
+  nrf5_bsp_btn_ble
+  nrf5_crc16
+  nrf5_drv_clock
+  nrf5_drv_uart
+  nrf5_ext_fprintf
+  nrf5_ext_segger_rtt
+  nrf5_ext_utf_converter
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_fstorage_sd
+  nrf5_hardfault
+  nrf5_log
+  nrf5_log_backend_rtt
+  nrf5_log_backend_serial
+  nrf5_log_backend_uart
+  nrf5_log_default_backends
+  nrf5_mdk
+  nrf5_memobj
+  nrf5_nrfx_clock
+  nrf5_nrfx_gpiote
+  nrf5_nrfx_prs
+  nrf5_nrfx_soc
+  nrf5_nrfx_uart
+  nrf5_nrfx_uarte
+  nrf5_pwr_mgmt
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_sensorsim
+  nrf5_sortlist
+  nrf5_strerror
+)

--- a/ci/examples/ble_peripheral/experimental/ble_app_lns/CMakeLists.txt
+++ b/ci/examples/ble_peripheral/experimental/ble_app_lns/CMakeLists.txt
@@ -1,0 +1,100 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.14)
+project(ble_app_lns LANGUAGES C ASM)
+
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME}
+  "${NRF5_SDK_PATH}/examples/ble_peripheral/experimental/ble_app_lns/main.c"
+)
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+  nrf5_app_button
+  nrf5_app_error
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_assert
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_ble_advertising
+  nrf5_ble_auth_status_tracker
+  nrf5_ble_common
+  nrf5_ble_gatt
+  nrf5_ble_gatt_cache_manager
+  nrf5_ble_id_manager
+  nrf5_ble_peer_data_storage
+  nrf5_ble_peer_database
+  nrf5_ble_peer_id
+  nrf5_ble_peer_manager
+  nrf5_ble_peer_manager_handler
+  nrf5_ble_pm_buffer
+  nrf5_ble_qwr
+  nrf5_ble_security_dispatcher
+  nrf5_ble_security_manager
+  nrf5_ble_srv_bas
+  nrf5_ble_srv_dis
+  nrf5_ble_srv_lns
+  nrf5_boards
+  nrf5_bsp
+  nrf5_bsp_btn_ble
+  nrf5_crc16
+  nrf5_drv_clock
+  nrf5_drv_uart
+  nrf5_ext_fprintf
+  nrf5_ext_segger_rtt
+  nrf5_ext_utf_converter
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_fstorage_sd
+  nrf5_hardfault
+  nrf5_log
+  nrf5_log_backend_rtt
+  nrf5_log_backend_serial
+  nrf5_log_backend_uart
+  nrf5_log_default_backends
+  nrf5_mdk
+  nrf5_memobj
+  nrf5_nrfx_clock
+  nrf5_nrfx_gpiote
+  nrf5_nrfx_prs
+  nrf5_nrfx_soc
+  nrf5_nrfx_uart
+  nrf5_nrfx_uarte
+  nrf5_pwr_mgmt
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_sensorsim
+  nrf5_sortlist
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+    nrf5_ble_gq
+    nrf5_queue
+  )
+endif()

--- a/ci/libraries/nrf5_ble_srv.json
+++ b/ci/libraries/nrf5_ble_srv.json
@@ -213,5 +213,57 @@
         "components/ble/ble_services/ble_ans_c"
       ]
     }
+  },
+  "nrf5_ble_srv_rscs": {
+    "documentation": "BLE Running Speed and Cadence Service (Peripheral)",
+    "variant": "object",
+    "sources": [
+      "components/ble/ble_services/ble_rscs/ble_rscs.c"
+    ],
+    "dependencies": {
+      "public": [
+        "nrf5_ble_common"
+      ]
+    },
+    "includes": {
+      "public": [
+        "components/ble/ble_services/ble_rscs"
+      ]
+    }
+  },
+  "nrf5_ble_srv_hids": {
+    "documentation": "BLE HID Service",
+    "variant": "object",
+    "sources": [
+      "components/ble/ble_services/ble_hids/ble_hids.c"
+    ],
+    "dependencies": {
+      "public": [
+        "nrf5_ble_common",
+        "nrf5_ble_link_ctx_manager"
+      ]
+    },
+    "includes": {
+      "public": [
+        "components/ble/ble_services/ble_hids"
+      ]
+    }
+  },
+  "nrf5_ble_srv_bas": {
+    "documentation": "BLE Battery Service (Peripheral)",
+    "variant": "object",
+    "sources": [
+      "components/ble/ble_services/ble_bas/ble_bas.c"
+    ],
+    "dependencies": {
+      "public": [
+        "nrf5_ble_common"
+      ]
+    },
+    "includes": {
+      "public": [
+        "components/ble/ble_services/ble_bas"
+      ]
+    }
   }
 }

--- a/ci/libraries/nrf5_ble_srv.json
+++ b/ci/libraries/nrf5_ble_srv.json
@@ -265,5 +265,35 @@
         "components/ble/ble_services/ble_bas"
       ]
     }
+  },
+  "nrf5_ble_srv_hts": {
+    "documentation": "BLE Health Thermometer Service",
+    "variant": "object",
+    "sources": [
+      "components/ble/ble_services/ble_hts/ble_hts.c"
+    ],
+    "dependencies": {
+      "public": [
+        "nrf5_ble_common"
+      ]
+    },
+    "includes": {
+      "public": [
+        "components/ble/ble_services/ble_hts"
+      ]
+    },
+    "patches": [
+      {
+        "operation": "add",
+        "sdk_version": {
+          "from": "16.0.0"
+        },
+        "dependencies": {
+          "public": [
+            "nrf5_ble_gq"
+          ]
+        }
+      }
+    ]
   }
 }

--- a/ci/libraries/nrf5_ble_srv.json
+++ b/ci/libraries/nrf5_ble_srv.json
@@ -295,5 +295,35 @@
         }
       }
     ]
+  },
+  "nrf5_ble_srv_bps": {
+    "documentation": "BLE Blood Pressure Service (Peripheral)",
+    "variant": "object",
+    "sources": [
+      "components/ble/ble_services/ble_bps/ble_bps.c"
+    ],
+    "dependencies": {
+      "public": [
+        "nrf5_ble_common"
+      ]
+    },
+    "includes": {
+      "public": [
+        "components/ble/ble_services/ble_bps"
+      ]
+    },
+    "patches": [
+      {
+        "operation": "add",
+        "sdk_version": {
+          "from": "16.0.0"
+        },
+        "dependencies": {
+          "public": [
+            "nrf5_ble_gq"
+          ]
+        }
+      }
+    ]
   }
 }

--- a/ci/libraries/nrf5_ble_srv.json
+++ b/ci/libraries/nrf5_ble_srv.json
@@ -162,5 +162,22 @@
         "components/ble/ble_services/ble_ias_c"
       ]
     }
+  },
+  "nrf5_ble_srv_gatts_c": {
+    "documentation": "BLE GATT Service Server (Central)",
+    "variant": "object",
+    "sources": [
+      "components/ble/ble_services/experimental_gatts_c/nrf_ble_gatts_c.c"
+    ],
+    "dependencies": {
+      "public": [
+        "nrf5_ble_db_discovery"
+      ]
+    },
+    "includes": {
+      "public": [
+        "components/ble/ble_services/experimental_gatts_c"
+      ]
+    }
   }
 }

--- a/ci/libraries/nrf5_ble_srv.json
+++ b/ci/libraries/nrf5_ble_srv.json
@@ -196,5 +196,22 @@
         "components/ble/ble_services/ble_cts_c"
       ]
     }
+  },
+  "nrf5_ble_srv_ans_c": {
+    "documentation": "BLE Alert Notification Client (Central)",
+    "variant": "object",
+    "sources": [
+      "components/ble/ble_services/ble_ans_c/ble_ans_c.c"
+    ],
+    "dependencies": {
+      "public": [
+        "nrf5_ble_db_discovery"
+      ]
+    },
+    "includes": {
+      "public": [
+        "components/ble/ble_services/ble_ans_c"
+      ]
+    }
   }
 }

--- a/ci/libraries/nrf5_ble_srv.json
+++ b/ci/libraries/nrf5_ble_srv.json
@@ -179,5 +179,22 @@
         "components/ble/ble_services/experimental_gatts_c"
       ]
     }
+  },
+  "nrf5_ble_srv_cts_c": {
+    "documentation": "BLE Current Time Service Client (Central)",
+    "variant": "object",
+    "sources": [
+      "components/ble/ble_services/ble_cts_c/ble_cts_c.c"
+    ],
+    "dependencies": {
+      "public": [
+        "nrf5_ble_db_discovery"
+      ]
+    },
+    "includes": {
+      "public": [
+        "components/ble/ble_services/ble_cts_c"
+      ]
+    }
   }
 }

--- a/ci/libraries/nrf5_ble_srv.json
+++ b/ci/libraries/nrf5_ble_srv.json
@@ -325,5 +325,23 @@
         }
       }
     ]
+  },
+  "nrf5_ble_srv_cscs": {
+    "documentation": "BLE Cycling Speed and Cadence Service",
+    "variant": "object",
+    "sources": [
+      "components/ble/ble_services/ble_cscs/ble_cscs.c",
+      "components/ble/ble_services/ble_cscs/ble_sc_ctrlpt.c"
+    ],
+    "dependencies": {
+      "public": [
+        "nrf5_ble_common"
+      ]
+    },
+    "includes": {
+      "public": [
+        "components/ble/ble_services/ble_cscs"
+      ]
+    }
   }
 }

--- a/ci/libraries/nrf5_ble_srv.json
+++ b/ci/libraries/nrf5_ble_srv.json
@@ -343,5 +343,37 @@
         "components/ble/ble_services/ble_cscs"
       ]
     }
+  },
+  "nrf5_ble_srv_lns": {
+    "documentation": "BLE Location and Navigation Service",
+    "variant": "object",
+    "sources": [
+      "components/ble/ble_services/experimental_ble_lns/ble_ln_cp.c",
+      "components/ble/ble_services/experimental_ble_lns/ble_ln_db.c",
+      "components/ble/ble_services/experimental_ble_lns/ble_lns.c"
+    ],
+    "dependencies": {
+      "public": [
+        "nrf5_ble_common"
+      ]
+    },
+    "includes": {
+      "public": [
+        "components/ble/ble_services/experimental_ble_lns"
+      ]
+    },
+    "patches": [
+      {
+        "operation": "add",
+        "sdk_version": {
+          "from": "16.0.0"
+        },
+        "dependencies": {
+          "public": [
+            "nrf5_ble_gq"
+          ]
+        }
+      }
+    ]
   }
 }

--- a/ci/libraries/nrf5_common.json
+++ b/ci/libraries/nrf5_common.json
@@ -115,7 +115,8 @@
         "nrf5_app_util_platform",
         "nrf5_log_fwd",
         "nrf5_section",
-        "nrf5_strerror"
+        "nrf5_strerror",
+        "nrf5_app_scheduler"
       ]
     },
     "includes": {

--- a/ci/libraries_tests/nrf5_app_error/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_error/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_app_error
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_app_uart/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_uart/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_uart
   nrf5_app_util_platform
   nrf5_atfifo

--- a/ci/libraries_tests/nrf5_app_uart_fifo/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_uart_fifo/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_app_fifo
+  nrf5_app_scheduler
   nrf5_app_uart_fifo
   nrf5_app_util_platform
   nrf5_atfifo

--- a/ci/libraries_tests/nrf5_app_usbd/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_usbd/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_util_platform
   nrf5_atfifo

--- a/ci/libraries_tests/nrf5_app_usbd_audio/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_usbd_audio/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_usbd_audio
   nrf5_app_util_platform

--- a/ci/libraries_tests/nrf5_app_usbd_cdc_acm/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_usbd_cdc_acm/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_usbd_cdc_acm
   nrf5_app_util_platform

--- a/ci/libraries_tests/nrf5_app_usbd_dummy/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_usbd_dummy/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_usbd_dummy
   nrf5_app_util_platform

--- a/ci/libraries_tests/nrf5_app_usbd_hid/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_usbd_hid/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_usbd_hid
   nrf5_app_util_platform

--- a/ci/libraries_tests/nrf5_app_usbd_hid_generic/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_usbd_hid_generic/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_usbd_hid
   nrf5_app_usbd_hid_generic

--- a/ci/libraries_tests/nrf5_app_usbd_hid_kbd/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_usbd_hid_kbd/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_usbd_hid
   nrf5_app_usbd_hid_kbd

--- a/ci/libraries_tests/nrf5_app_usbd_hid_mouse/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_usbd_hid_mouse/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_usbd_hid
   nrf5_app_usbd_hid_mouse

--- a/ci/libraries_tests/nrf5_app_usbd_msc/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_usbd_msc/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_usbd_msc
   nrf5_app_util_platform

--- a/ci/libraries_tests/nrf5_app_usbd_nrf_dfu_trigger/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_usbd_nrf_dfu_trigger/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_usbd_nrf_dfu_trigger
   nrf5_app_util_platform

--- a/ci/libraries_tests/nrf5_app_usbd_serial_num/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_usbd_serial_num/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_usbd_serial_num
   nrf5_app_util_platform

--- a/ci/libraries_tests/nrf5_ble_gatt/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_gatt/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_ble_lesc/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_lesc/CMakeLists.txt
@@ -33,6 +33,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_ble_srv_ans_c/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_ans_c/CMakeLists.txt
@@ -1,0 +1,72 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# WARNING: FILE GENERATED FROM ./ci/scripts/generate_cmake_tests.sh SCRIPT.
+
+cmake_minimum_required(VERSION 3.14)
+project(nrf5_ble_srv_ans_c_test LANGUAGES C ASM)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../../cmake")
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME} "main.c")
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_balloc_fwd
+  nrf5_ble_common
+  nrf5_ble_db_discovery
+  nrf5_ble_srv_ans_c
+  nrf5_cli
+  nrf5_cli_fwd
+  nrf5_config
+  nrf5_delay
+  nrf5_ext_fprintf
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_log
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_memobj
+  nrf5_memobj_fwd
+  nrf5_mtx
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_pwr_mgmt
+  nrf5_queue
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+    nrf5_ble_gq
+  )
+endif()

--- a/ci/libraries_tests/nrf5_ble_srv_ans_c/main.c
+++ b/ci/libraries_tests/nrf5_ble_srv_ans_c/main.c
@@ -1,0 +1,13 @@
+#include "ble_ans_c.h"
+
+void app_error_handler_bare(uint32_t error_code)
+{
+}
+
+int main()
+{
+    ble_ans_c_t ans;
+    ble_ans_c_init_t ans_init;
+    ble_ans_c_init(&ans, &ans_init);
+    return 0;
+}

--- a/ci/libraries_tests/nrf5_ble_srv_ans_c/sdk_config.h
+++ b/ci/libraries_tests/nrf5_ble_srv_ans_c/sdk_config.h
@@ -1,0 +1,237 @@
+#ifndef SDK_CONFIG_H
+#define SDK_CONFIG_H
+
+#ifndef NRF_LOG_ENABLED
+#define NRF_LOG_ENABLED 0
+#endif
+
+// </h>
+//==========================================================
+
+// </h>
+//==========================================================
+
+// <h> nRF_SoftDevice
+
+//==========================================================
+// <e> NRF_SDH_BLE_ENABLED - nrf_sdh_ble - SoftDevice BLE event handler
+//==========================================================
+#ifndef NRF_SDH_BLE_ENABLED
+#define NRF_SDH_BLE_ENABLED 1
+#endif
+// <h> BLE Stack configuration - Stack configuration parameters
+
+// <i> The SoftDevice handler will configure the stack with these parameters when calling @ref nrf_sdh_ble_default_cfg_set.
+// <i> Other libraries might depend on these values; keep them up-to-date even if you are not explicitely calling @ref nrf_sdh_ble_default_cfg_set.
+//==========================================================
+// <o> NRF_SDH_BLE_GAP_DATA_LENGTH   <27-251>
+
+// <i> Requested BLE GAP data length to be negotiated.
+
+#ifndef NRF_SDH_BLE_GAP_DATA_LENGTH
+#define NRF_SDH_BLE_GAP_DATA_LENGTH 27
+#endif
+
+// <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links.
+#ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links.
+#ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count.
+// <i> Maximum number of total concurrent connections using the default configuration.
+
+#ifndef NRF_SDH_BLE_TOTAL_LINK_COUNT
+#define NRF_SDH_BLE_TOTAL_LINK_COUNT 1
+#endif
+
+// <o> NRF_SDH_BLE_GAP_EVENT_LENGTH - GAP event length.
+// <i> The time set aside for this connection on every connection interval in 1.25 ms units.
+
+#ifndef NRF_SDH_BLE_GAP_EVENT_LENGTH
+#define NRF_SDH_BLE_GAP_EVENT_LENGTH 6
+#endif
+
+// <o> NRF_SDH_BLE_GATT_MAX_MTU_SIZE - Static maximum MTU size.
+#ifndef NRF_SDH_BLE_GATT_MAX_MTU_SIZE
+#define NRF_SDH_BLE_GATT_MAX_MTU_SIZE 23
+#endif
+
+// <o> NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE - Attribute Table size in bytes. The size must be a multiple of 4.
+#ifndef NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE
+#define NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE 1408
+#endif
+
+// <o> NRF_SDH_BLE_VS_UUID_COUNT - The number of vendor-specific UUIDs.
+#ifndef NRF_SDH_BLE_VS_UUID_COUNT
+#define NRF_SDH_BLE_VS_UUID_COUNT 0
+#endif
+
+// <q> NRF_SDH_BLE_SERVICE_CHANGED  - Include the Service Changed characteristic in the Attribute Table.
+
+#ifndef NRF_SDH_BLE_SERVICE_CHANGED
+#define NRF_SDH_BLE_SERVICE_CHANGED 0
+#endif
+
+// <e> NRF_SDH_SOC_ENABLED - nrf_sdh_soc - SoftDevice SoC event handler
+//==========================================================
+#ifndef NRF_SDH_SOC_ENABLED
+#define NRF_SDH_SOC_ENABLED 1
+#endif
+// <h> SoC Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_SOC_OBSERVER_PRIO_LEVELS - Total number of priority levels for SoC observers.
+// <i> This setting configures the number of priority levels available for the SoC event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_SOC_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_SOC_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <h> SoC Observers priorities - Invididual priorities
+
+// <e> NRF_SDH_ENABLED - nrf_sdh - SoftDevice handler
+//==========================================================
+#ifndef NRF_SDH_ENABLED
+#define NRF_SDH_ENABLED 1
+#endif
+
+// </h>
+//==========================================================
+
+// <h> Clock - SoftDevice clock configuration
+
+//==========================================================
+// <o> NRF_SDH_CLOCK_LF_SRC  - SoftDevice clock source.
+
+// <0=> NRF_CLOCK_LF_SRC_RC
+// <1=> NRF_CLOCK_LF_SRC_XTAL
+// <2=> NRF_CLOCK_LF_SRC_SYNTH
+
+#ifndef NRF_SDH_CLOCK_LF_SRC
+#define NRF_SDH_CLOCK_LF_SRC 1
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_CTIV - SoftDevice calibration timer interval.
+#ifndef NRF_SDH_CLOCK_LF_RC_CTIV
+#define NRF_SDH_CLOCK_LF_RC_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_TEMP_CTIV - SoftDevice calibration timer interval under constant temperature.
+// <i> How often (in number of calibration intervals) the RC oscillator shall be calibrated
+// <i>  if the temperature has not changed.
+
+#ifndef NRF_SDH_CLOCK_LF_RC_TEMP_CTIV
+#define NRF_SDH_CLOCK_LF_RC_TEMP_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_ACCURACY  - External clock accuracy used in the LL to compute timing.
+
+// <0=> NRF_CLOCK_LF_ACCURACY_250_PPM
+// <1=> NRF_CLOCK_LF_ACCURACY_500_PPM
+// <2=> NRF_CLOCK_LF_ACCURACY_150_PPM
+// <3=> NRF_CLOCK_LF_ACCURACY_100_PPM
+// <4=> NRF_CLOCK_LF_ACCURACY_75_PPM
+// <5=> NRF_CLOCK_LF_ACCURACY_50_PPM
+// <6=> NRF_CLOCK_LF_ACCURACY_30_PPM
+// <7=> NRF_CLOCK_LF_ACCURACY_20_PPM
+// <8=> NRF_CLOCK_LF_ACCURACY_10_PPM
+// <9=> NRF_CLOCK_LF_ACCURACY_5_PPM
+// <10=> NRF_CLOCK_LF_ACCURACY_2_PPM
+// <11=> NRF_CLOCK_LF_ACCURACY_1_PPM
+
+#ifndef NRF_SDH_CLOCK_LF_ACCURACY
+#define NRF_SDH_CLOCK_LF_ACCURACY 7
+#endif
+
+// <o> NRF_SDH_SOC_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which SoC events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have SoC events dispatched before or after other stack events, such as ANT or BLE.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_SOC_STACK_OBSERVER_PRIO
+#define NRF_SDH_SOC_STACK_OBSERVER_PRIO 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> BLE Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_BLE_OBSERVER_PRIO_LEVELS - Total number of priority levels for BLE observers.
+// <i> This setting configures the number of priority levels available for BLE event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_BLE_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_BLE_OBSERVER_PRIO_LEVELS 4
+#endif
+
+// <h> BLE Observers priorities - Invididual priorities
+
+//==========================================================
+// <o> BLE_ADV_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Advertising module.
+
+#ifndef BLE_ADV_BLE_OBSERVER_PRIO
+#define BLE_ADV_BLE_OBSERVER_PRIO 1
+#endif
+
+// <o> BLE_CONN_STATE_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Connection State module.
+
+#ifndef BLE_CONN_STATE_BLE_OBSERVER_PRIO
+#define BLE_CONN_STATE_BLE_OBSERVER_PRIO 0
+#endif
+
+// <o> NRF_SDH_STACK_OBSERVER_PRIO_LEVELS - Total number of priority levels for stack event observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice stack event handlers (ANT, BLE, SoC).
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STACK_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_BLE_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which BLE events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have BLE events dispatched before or after other stack events, such as ANT or SoC.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_BLE_STACK_OBSERVER_PRIO
+#define NRF_SDH_BLE_STACK_OBSERVER_PRIO 0
+#endif
+
+//---
+
+// <e> NRF_BLE_QWR_ENABLED - nrf_ble_qwr - Queued writes support module (prepare/execute write)
+//==========================================================
+#ifndef NRF_BLE_QWR_ENABLED
+#define NRF_BLE_QWR_ENABLED 1
+#endif
+// <o> NRF_BLE_QWR_MAX_ATTR - Maximum number of attribute handles that can be registered. This number must be adjusted according to the number of attributes for which Queued Writes will be enabled. If it is zero, the module will reject all Queued Write requests.
+#ifndef NRF_BLE_QWR_MAX_ATTR
+#define NRF_BLE_QWR_MAX_ATTR 1
+#endif
+
+// <q> NRF_SECTION_ITER_ENABLED  - nrf_section_iter - Section iterator
+
+#ifndef NRF_SECTION_ITER_ENABLED
+#define NRF_SECTION_ITER_ENABLED 1
+#endif
+
+//---
+
+#ifndef BLE_ANS_C_ENABLED
+#define BLE_ANS_C_ENABLED 1
+#endif
+
+#ifndef BLE_DB_DISCOVERY_ENABLED
+#define BLE_DB_DISCOVERY_ENABLED 1
+#endif
+
+#endif // SDK_CONFIG_H

--- a/ci/libraries_tests/nrf5_ble_srv_bas/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_bas/CMakeLists.txt
@@ -1,0 +1,51 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# WARNING: FILE GENERATED FROM ./ci/scripts/generate_cmake_tests.sh SCRIPT.
+
+cmake_minimum_required(VERSION 3.14)
+project(nrf5_ble_srv_bas_test LANGUAGES C ASM)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../../cmake")
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME} "main.c")
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_srv_bas
+  nrf5_config
+  nrf5_delay
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)

--- a/ci/libraries_tests/nrf5_ble_srv_bas/main.c
+++ b/ci/libraries_tests/nrf5_ble_srv_bas/main.c
@@ -1,0 +1,13 @@
+#include "ble_bas.h"
+
+void app_error_handler_bare(uint32_t error_code)
+{
+}
+
+int main()
+{
+    ble_bas_t bas;
+    ble_bas_init_t bas_init;
+    ble_bas_init(&bas, &bas_init);
+    return 0;
+}

--- a/ci/libraries_tests/nrf5_ble_srv_bas/sdk_config.h
+++ b/ci/libraries_tests/nrf5_ble_srv_bas/sdk_config.h
@@ -1,0 +1,233 @@
+#ifndef SDK_CONFIG_H
+#define SDK_CONFIG_H
+
+#ifndef NRF_LOG_ENABLED
+#define NRF_LOG_ENABLED 0
+#endif
+
+// </h>
+//==========================================================
+
+// </h>
+//==========================================================
+
+// <h> nRF_SoftDevice
+
+//==========================================================
+// <e> NRF_SDH_BLE_ENABLED - nrf_sdh_ble - SoftDevice BLE event handler
+//==========================================================
+#ifndef NRF_SDH_BLE_ENABLED
+#define NRF_SDH_BLE_ENABLED 1
+#endif
+// <h> BLE Stack configuration - Stack configuration parameters
+
+// <i> The SoftDevice handler will configure the stack with these parameters when calling @ref nrf_sdh_ble_default_cfg_set.
+// <i> Other libraries might depend on these values; keep them up-to-date even if you are not explicitely calling @ref nrf_sdh_ble_default_cfg_set.
+//==========================================================
+// <o> NRF_SDH_BLE_GAP_DATA_LENGTH   <27-251>
+
+// <i> Requested BLE GAP data length to be negotiated.
+
+#ifndef NRF_SDH_BLE_GAP_DATA_LENGTH
+#define NRF_SDH_BLE_GAP_DATA_LENGTH 27
+#endif
+
+// <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links.
+#ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links.
+#ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count.
+// <i> Maximum number of total concurrent connections using the default configuration.
+
+#ifndef NRF_SDH_BLE_TOTAL_LINK_COUNT
+#define NRF_SDH_BLE_TOTAL_LINK_COUNT 1
+#endif
+
+// <o> NRF_SDH_BLE_GAP_EVENT_LENGTH - GAP event length.
+// <i> The time set aside for this connection on every connection interval in 1.25 ms units.
+
+#ifndef NRF_SDH_BLE_GAP_EVENT_LENGTH
+#define NRF_SDH_BLE_GAP_EVENT_LENGTH 6
+#endif
+
+// <o> NRF_SDH_BLE_GATT_MAX_MTU_SIZE - Static maximum MTU size.
+#ifndef NRF_SDH_BLE_GATT_MAX_MTU_SIZE
+#define NRF_SDH_BLE_GATT_MAX_MTU_SIZE 23
+#endif
+
+// <o> NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE - Attribute Table size in bytes. The size must be a multiple of 4.
+#ifndef NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE
+#define NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE 1408
+#endif
+
+// <o> NRF_SDH_BLE_VS_UUID_COUNT - The number of vendor-specific UUIDs.
+#ifndef NRF_SDH_BLE_VS_UUID_COUNT
+#define NRF_SDH_BLE_VS_UUID_COUNT 0
+#endif
+
+// <q> NRF_SDH_BLE_SERVICE_CHANGED  - Include the Service Changed characteristic in the Attribute Table.
+
+#ifndef NRF_SDH_BLE_SERVICE_CHANGED
+#define NRF_SDH_BLE_SERVICE_CHANGED 0
+#endif
+
+// <e> NRF_SDH_SOC_ENABLED - nrf_sdh_soc - SoftDevice SoC event handler
+//==========================================================
+#ifndef NRF_SDH_SOC_ENABLED
+#define NRF_SDH_SOC_ENABLED 1
+#endif
+// <h> SoC Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_SOC_OBSERVER_PRIO_LEVELS - Total number of priority levels for SoC observers.
+// <i> This setting configures the number of priority levels available for the SoC event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_SOC_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_SOC_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <h> SoC Observers priorities - Invididual priorities
+
+// <e> NRF_SDH_ENABLED - nrf_sdh - SoftDevice handler
+//==========================================================
+#ifndef NRF_SDH_ENABLED
+#define NRF_SDH_ENABLED 1
+#endif
+
+// </h>
+//==========================================================
+
+// <h> Clock - SoftDevice clock configuration
+
+//==========================================================
+// <o> NRF_SDH_CLOCK_LF_SRC  - SoftDevice clock source.
+
+// <0=> NRF_CLOCK_LF_SRC_RC
+// <1=> NRF_CLOCK_LF_SRC_XTAL
+// <2=> NRF_CLOCK_LF_SRC_SYNTH
+
+#ifndef NRF_SDH_CLOCK_LF_SRC
+#define NRF_SDH_CLOCK_LF_SRC 1
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_CTIV - SoftDevice calibration timer interval.
+#ifndef NRF_SDH_CLOCK_LF_RC_CTIV
+#define NRF_SDH_CLOCK_LF_RC_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_TEMP_CTIV - SoftDevice calibration timer interval under constant temperature.
+// <i> How often (in number of calibration intervals) the RC oscillator shall be calibrated
+// <i>  if the temperature has not changed.
+
+#ifndef NRF_SDH_CLOCK_LF_RC_TEMP_CTIV
+#define NRF_SDH_CLOCK_LF_RC_TEMP_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_ACCURACY  - External clock accuracy used in the LL to compute timing.
+
+// <0=> NRF_CLOCK_LF_ACCURACY_250_PPM
+// <1=> NRF_CLOCK_LF_ACCURACY_500_PPM
+// <2=> NRF_CLOCK_LF_ACCURACY_150_PPM
+// <3=> NRF_CLOCK_LF_ACCURACY_100_PPM
+// <4=> NRF_CLOCK_LF_ACCURACY_75_PPM
+// <5=> NRF_CLOCK_LF_ACCURACY_50_PPM
+// <6=> NRF_CLOCK_LF_ACCURACY_30_PPM
+// <7=> NRF_CLOCK_LF_ACCURACY_20_PPM
+// <8=> NRF_CLOCK_LF_ACCURACY_10_PPM
+// <9=> NRF_CLOCK_LF_ACCURACY_5_PPM
+// <10=> NRF_CLOCK_LF_ACCURACY_2_PPM
+// <11=> NRF_CLOCK_LF_ACCURACY_1_PPM
+
+#ifndef NRF_SDH_CLOCK_LF_ACCURACY
+#define NRF_SDH_CLOCK_LF_ACCURACY 7
+#endif
+
+// <o> NRF_SDH_SOC_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which SoC events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have SoC events dispatched before or after other stack events, such as ANT or BLE.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_SOC_STACK_OBSERVER_PRIO
+#define NRF_SDH_SOC_STACK_OBSERVER_PRIO 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> BLE Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_BLE_OBSERVER_PRIO_LEVELS - Total number of priority levels for BLE observers.
+// <i> This setting configures the number of priority levels available for BLE event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_BLE_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_BLE_OBSERVER_PRIO_LEVELS 4
+#endif
+
+// <h> BLE Observers priorities - Invididual priorities
+
+//==========================================================
+// <o> BLE_ADV_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Advertising module.
+
+#ifndef BLE_ADV_BLE_OBSERVER_PRIO
+#define BLE_ADV_BLE_OBSERVER_PRIO 1
+#endif
+
+// <o> BLE_CONN_STATE_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Connection State module.
+
+#ifndef BLE_CONN_STATE_BLE_OBSERVER_PRIO
+#define BLE_CONN_STATE_BLE_OBSERVER_PRIO 0
+#endif
+
+// <o> NRF_SDH_STACK_OBSERVER_PRIO_LEVELS - Total number of priority levels for stack event observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice stack event handlers (ANT, BLE, SoC).
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STACK_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_BLE_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which BLE events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have BLE events dispatched before or after other stack events, such as ANT or SoC.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_BLE_STACK_OBSERVER_PRIO
+#define NRF_SDH_BLE_STACK_OBSERVER_PRIO 0
+#endif
+
+//---
+
+// <e> NRF_BLE_QWR_ENABLED - nrf_ble_qwr - Queued writes support module (prepare/execute write)
+//==========================================================
+#ifndef NRF_BLE_QWR_ENABLED
+#define NRF_BLE_QWR_ENABLED 1
+#endif
+// <o> NRF_BLE_QWR_MAX_ATTR - Maximum number of attribute handles that can be registered. This number must be adjusted according to the number of attributes for which Queued Writes will be enabled. If it is zero, the module will reject all Queued Write requests.
+#ifndef NRF_BLE_QWR_MAX_ATTR
+#define NRF_BLE_QWR_MAX_ATTR 1
+#endif
+
+// <q> NRF_SECTION_ITER_ENABLED  - nrf_section_iter - Section iterator
+
+#ifndef NRF_SECTION_ITER_ENABLED
+#define NRF_SECTION_ITER_ENABLED 1
+#endif
+
+//---
+
+#ifndef BLE_BAS_ENABLED
+#define BLE_BAS_ENABLED 1
+#endif
+
+#endif // SDK_CONFIG_H

--- a/ci/libraries_tests/nrf5_ble_srv_bps/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_bps/CMakeLists.txt
@@ -1,0 +1,63 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# WARNING: FILE GENERATED FROM ./ci/scripts/generate_cmake_tests.sh SCRIPT.
+
+cmake_minimum_required(VERSION 3.14)
+project(nrf5_ble_srv_bps_test LANGUAGES C ASM)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../../cmake")
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME} "main.c")
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_srv_bps
+  nrf5_config
+  nrf5_delay
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+    nrf5_balloc
+    nrf5_balloc_fwd
+    nrf5_ble_gq
+    nrf5_cli_fwd
+    nrf5_ext_fprintf
+    nrf5_memobj
+    nrf5_memobj_fwd
+    nrf5_queue
+  )
+endif()

--- a/ci/libraries_tests/nrf5_ble_srv_bps/main.c
+++ b/ci/libraries_tests/nrf5_ble_srv_bps/main.c
@@ -1,0 +1,13 @@
+#include "ble_bps.h"
+
+void app_error_handler_bare(uint32_t error_code)
+{
+}
+
+int main()
+{
+    ble_bps_t bps;
+    ble_bps_init_t bps_init;
+    ble_bps_init(&bps, &bps_init);
+    return 0;
+}

--- a/ci/libraries_tests/nrf5_ble_srv_bps/sdk_config.h
+++ b/ci/libraries_tests/nrf5_ble_srv_bps/sdk_config.h
@@ -1,0 +1,233 @@
+#ifndef SDK_CONFIG_H
+#define SDK_CONFIG_H
+
+#ifndef NRF_LOG_ENABLED
+#define NRF_LOG_ENABLED 0
+#endif
+
+// </h>
+//==========================================================
+
+// </h>
+//==========================================================
+
+// <h> nRF_SoftDevice
+
+//==========================================================
+// <e> NRF_SDH_BLE_ENABLED - nrf_sdh_ble - SoftDevice BLE event handler
+//==========================================================
+#ifndef NRF_SDH_BLE_ENABLED
+#define NRF_SDH_BLE_ENABLED 1
+#endif
+// <h> BLE Stack configuration - Stack configuration parameters
+
+// <i> The SoftDevice handler will configure the stack with these parameters when calling @ref nrf_sdh_ble_default_cfg_set.
+// <i> Other libraries might depend on these values; keep them up-to-date even if you are not explicitely calling @ref nrf_sdh_ble_default_cfg_set.
+//==========================================================
+// <o> NRF_SDH_BLE_GAP_DATA_LENGTH   <27-251>
+
+// <i> Requested BLE GAP data length to be negotiated.
+
+#ifndef NRF_SDH_BLE_GAP_DATA_LENGTH
+#define NRF_SDH_BLE_GAP_DATA_LENGTH 27
+#endif
+
+// <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links.
+#ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links.
+#ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count.
+// <i> Maximum number of total concurrent connections using the default configuration.
+
+#ifndef NRF_SDH_BLE_TOTAL_LINK_COUNT
+#define NRF_SDH_BLE_TOTAL_LINK_COUNT 1
+#endif
+
+// <o> NRF_SDH_BLE_GAP_EVENT_LENGTH - GAP event length.
+// <i> The time set aside for this connection on every connection interval in 1.25 ms units.
+
+#ifndef NRF_SDH_BLE_GAP_EVENT_LENGTH
+#define NRF_SDH_BLE_GAP_EVENT_LENGTH 6
+#endif
+
+// <o> NRF_SDH_BLE_GATT_MAX_MTU_SIZE - Static maximum MTU size.
+#ifndef NRF_SDH_BLE_GATT_MAX_MTU_SIZE
+#define NRF_SDH_BLE_GATT_MAX_MTU_SIZE 23
+#endif
+
+// <o> NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE - Attribute Table size in bytes. The size must be a multiple of 4.
+#ifndef NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE
+#define NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE 1408
+#endif
+
+// <o> NRF_SDH_BLE_VS_UUID_COUNT - The number of vendor-specific UUIDs.
+#ifndef NRF_SDH_BLE_VS_UUID_COUNT
+#define NRF_SDH_BLE_VS_UUID_COUNT 0
+#endif
+
+// <q> NRF_SDH_BLE_SERVICE_CHANGED  - Include the Service Changed characteristic in the Attribute Table.
+
+#ifndef NRF_SDH_BLE_SERVICE_CHANGED
+#define NRF_SDH_BLE_SERVICE_CHANGED 0
+#endif
+
+// <e> NRF_SDH_SOC_ENABLED - nrf_sdh_soc - SoftDevice SoC event handler
+//==========================================================
+#ifndef NRF_SDH_SOC_ENABLED
+#define NRF_SDH_SOC_ENABLED 1
+#endif
+// <h> SoC Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_SOC_OBSERVER_PRIO_LEVELS - Total number of priority levels for SoC observers.
+// <i> This setting configures the number of priority levels available for the SoC event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_SOC_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_SOC_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <h> SoC Observers priorities - Invididual priorities
+
+// <e> NRF_SDH_ENABLED - nrf_sdh - SoftDevice handler
+//==========================================================
+#ifndef NRF_SDH_ENABLED
+#define NRF_SDH_ENABLED 1
+#endif
+
+// </h>
+//==========================================================
+
+// <h> Clock - SoftDevice clock configuration
+
+//==========================================================
+// <o> NRF_SDH_CLOCK_LF_SRC  - SoftDevice clock source.
+
+// <0=> NRF_CLOCK_LF_SRC_RC
+// <1=> NRF_CLOCK_LF_SRC_XTAL
+// <2=> NRF_CLOCK_LF_SRC_SYNTH
+
+#ifndef NRF_SDH_CLOCK_LF_SRC
+#define NRF_SDH_CLOCK_LF_SRC 1
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_CTIV - SoftDevice calibration timer interval.
+#ifndef NRF_SDH_CLOCK_LF_RC_CTIV
+#define NRF_SDH_CLOCK_LF_RC_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_TEMP_CTIV - SoftDevice calibration timer interval under constant temperature.
+// <i> How often (in number of calibration intervals) the RC oscillator shall be calibrated
+// <i>  if the temperature has not changed.
+
+#ifndef NRF_SDH_CLOCK_LF_RC_TEMP_CTIV
+#define NRF_SDH_CLOCK_LF_RC_TEMP_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_ACCURACY  - External clock accuracy used in the LL to compute timing.
+
+// <0=> NRF_CLOCK_LF_ACCURACY_250_PPM
+// <1=> NRF_CLOCK_LF_ACCURACY_500_PPM
+// <2=> NRF_CLOCK_LF_ACCURACY_150_PPM
+// <3=> NRF_CLOCK_LF_ACCURACY_100_PPM
+// <4=> NRF_CLOCK_LF_ACCURACY_75_PPM
+// <5=> NRF_CLOCK_LF_ACCURACY_50_PPM
+// <6=> NRF_CLOCK_LF_ACCURACY_30_PPM
+// <7=> NRF_CLOCK_LF_ACCURACY_20_PPM
+// <8=> NRF_CLOCK_LF_ACCURACY_10_PPM
+// <9=> NRF_CLOCK_LF_ACCURACY_5_PPM
+// <10=> NRF_CLOCK_LF_ACCURACY_2_PPM
+// <11=> NRF_CLOCK_LF_ACCURACY_1_PPM
+
+#ifndef NRF_SDH_CLOCK_LF_ACCURACY
+#define NRF_SDH_CLOCK_LF_ACCURACY 7
+#endif
+
+// <o> NRF_SDH_SOC_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which SoC events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have SoC events dispatched before or after other stack events, such as ANT or BLE.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_SOC_STACK_OBSERVER_PRIO
+#define NRF_SDH_SOC_STACK_OBSERVER_PRIO 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> BLE Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_BLE_OBSERVER_PRIO_LEVELS - Total number of priority levels for BLE observers.
+// <i> This setting configures the number of priority levels available for BLE event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_BLE_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_BLE_OBSERVER_PRIO_LEVELS 4
+#endif
+
+// <h> BLE Observers priorities - Invididual priorities
+
+//==========================================================
+// <o> BLE_ADV_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Advertising module.
+
+#ifndef BLE_ADV_BLE_OBSERVER_PRIO
+#define BLE_ADV_BLE_OBSERVER_PRIO 1
+#endif
+
+// <o> BLE_CONN_STATE_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Connection State module.
+
+#ifndef BLE_CONN_STATE_BLE_OBSERVER_PRIO
+#define BLE_CONN_STATE_BLE_OBSERVER_PRIO 0
+#endif
+
+// <o> NRF_SDH_STACK_OBSERVER_PRIO_LEVELS - Total number of priority levels for stack event observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice stack event handlers (ANT, BLE, SoC).
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STACK_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_BLE_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which BLE events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have BLE events dispatched before or after other stack events, such as ANT or SoC.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_BLE_STACK_OBSERVER_PRIO
+#define NRF_SDH_BLE_STACK_OBSERVER_PRIO 0
+#endif
+
+//---
+
+// <e> NRF_BLE_QWR_ENABLED - nrf_ble_qwr - Queued writes support module (prepare/execute write)
+//==========================================================
+#ifndef NRF_BLE_QWR_ENABLED
+#define NRF_BLE_QWR_ENABLED 1
+#endif
+// <o> NRF_BLE_QWR_MAX_ATTR - Maximum number of attribute handles that can be registered. This number must be adjusted according to the number of attributes for which Queued Writes will be enabled. If it is zero, the module will reject all Queued Write requests.
+#ifndef NRF_BLE_QWR_MAX_ATTR
+#define NRF_BLE_QWR_MAX_ATTR 1
+#endif
+
+// <q> NRF_SECTION_ITER_ENABLED  - nrf_section_iter - Section iterator
+
+#ifndef NRF_SECTION_ITER_ENABLED
+#define NRF_SECTION_ITER_ENABLED 1
+#endif
+
+//---
+
+#ifndef BLE_BPS_ENABLED
+#define BLE_BPS_ENABLED 1
+#endif
+
+#endif // SDK_CONFIG_H

--- a/ci/libraries_tests/nrf5_ble_srv_cscs/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_cscs/CMakeLists.txt
@@ -1,0 +1,51 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# WARNING: FILE GENERATED FROM ./ci/scripts/generate_cmake_tests.sh SCRIPT.
+
+cmake_minimum_required(VERSION 3.14)
+project(nrf5_ble_srv_cscs_test LANGUAGES C ASM)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../../cmake")
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME} "main.c")
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_srv_cscs
+  nrf5_config
+  nrf5_delay
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)

--- a/ci/libraries_tests/nrf5_ble_srv_cscs/main.c
+++ b/ci/libraries_tests/nrf5_ble_srv_cscs/main.c
@@ -1,0 +1,13 @@
+#include "ble_cscs.h"
+
+void app_error_handler_bare(uint32_t error_code)
+{
+}
+
+int main()
+{
+    ble_cscs_t cscs;
+    ble_cscs_init_t cscs_init;
+    ble_cscs_init(&cscs, &cscs_init);
+    return 0;
+}

--- a/ci/libraries_tests/nrf5_ble_srv_cscs/sdk_config.h
+++ b/ci/libraries_tests/nrf5_ble_srv_cscs/sdk_config.h
@@ -1,0 +1,233 @@
+#ifndef SDK_CONFIG_H
+#define SDK_CONFIG_H
+
+#ifndef NRF_LOG_ENABLED
+#define NRF_LOG_ENABLED 0
+#endif
+
+// </h>
+//==========================================================
+
+// </h>
+//==========================================================
+
+// <h> nRF_SoftDevice
+
+//==========================================================
+// <e> NRF_SDH_BLE_ENABLED - nrf_sdh_ble - SoftDevice BLE event handler
+//==========================================================
+#ifndef NRF_SDH_BLE_ENABLED
+#define NRF_SDH_BLE_ENABLED 1
+#endif
+// <h> BLE Stack configuration - Stack configuration parameters
+
+// <i> The SoftDevice handler will configure the stack with these parameters when calling @ref nrf_sdh_ble_default_cfg_set.
+// <i> Other libraries might depend on these values; keep them up-to-date even if you are not explicitely calling @ref nrf_sdh_ble_default_cfg_set.
+//==========================================================
+// <o> NRF_SDH_BLE_GAP_DATA_LENGTH   <27-251>
+
+// <i> Requested BLE GAP data length to be negotiated.
+
+#ifndef NRF_SDH_BLE_GAP_DATA_LENGTH
+#define NRF_SDH_BLE_GAP_DATA_LENGTH 27
+#endif
+
+// <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links.
+#ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links.
+#ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count.
+// <i> Maximum number of total concurrent connections using the default configuration.
+
+#ifndef NRF_SDH_BLE_TOTAL_LINK_COUNT
+#define NRF_SDH_BLE_TOTAL_LINK_COUNT 1
+#endif
+
+// <o> NRF_SDH_BLE_GAP_EVENT_LENGTH - GAP event length.
+// <i> The time set aside for this connection on every connection interval in 1.25 ms units.
+
+#ifndef NRF_SDH_BLE_GAP_EVENT_LENGTH
+#define NRF_SDH_BLE_GAP_EVENT_LENGTH 6
+#endif
+
+// <o> NRF_SDH_BLE_GATT_MAX_MTU_SIZE - Static maximum MTU size.
+#ifndef NRF_SDH_BLE_GATT_MAX_MTU_SIZE
+#define NRF_SDH_BLE_GATT_MAX_MTU_SIZE 23
+#endif
+
+// <o> NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE - Attribute Table size in bytes. The size must be a multiple of 4.
+#ifndef NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE
+#define NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE 1408
+#endif
+
+// <o> NRF_SDH_BLE_VS_UUID_COUNT - The number of vendor-specific UUIDs.
+#ifndef NRF_SDH_BLE_VS_UUID_COUNT
+#define NRF_SDH_BLE_VS_UUID_COUNT 0
+#endif
+
+// <q> NRF_SDH_BLE_SERVICE_CHANGED  - Include the Service Changed characteristic in the Attribute Table.
+
+#ifndef NRF_SDH_BLE_SERVICE_CHANGED
+#define NRF_SDH_BLE_SERVICE_CHANGED 0
+#endif
+
+// <e> NRF_SDH_SOC_ENABLED - nrf_sdh_soc - SoftDevice SoC event handler
+//==========================================================
+#ifndef NRF_SDH_SOC_ENABLED
+#define NRF_SDH_SOC_ENABLED 1
+#endif
+// <h> SoC Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_SOC_OBSERVER_PRIO_LEVELS - Total number of priority levels for SoC observers.
+// <i> This setting configures the number of priority levels available for the SoC event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_SOC_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_SOC_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <h> SoC Observers priorities - Invididual priorities
+
+// <e> NRF_SDH_ENABLED - nrf_sdh - SoftDevice handler
+//==========================================================
+#ifndef NRF_SDH_ENABLED
+#define NRF_SDH_ENABLED 1
+#endif
+
+// </h>
+//==========================================================
+
+// <h> Clock - SoftDevice clock configuration
+
+//==========================================================
+// <o> NRF_SDH_CLOCK_LF_SRC  - SoftDevice clock source.
+
+// <0=> NRF_CLOCK_LF_SRC_RC
+// <1=> NRF_CLOCK_LF_SRC_XTAL
+// <2=> NRF_CLOCK_LF_SRC_SYNTH
+
+#ifndef NRF_SDH_CLOCK_LF_SRC
+#define NRF_SDH_CLOCK_LF_SRC 1
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_CTIV - SoftDevice calibration timer interval.
+#ifndef NRF_SDH_CLOCK_LF_RC_CTIV
+#define NRF_SDH_CLOCK_LF_RC_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_TEMP_CTIV - SoftDevice calibration timer interval under constant temperature.
+// <i> How often (in number of calibration intervals) the RC oscillator shall be calibrated
+// <i>  if the temperature has not changed.
+
+#ifndef NRF_SDH_CLOCK_LF_RC_TEMP_CTIV
+#define NRF_SDH_CLOCK_LF_RC_TEMP_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_ACCURACY  - External clock accuracy used in the LL to compute timing.
+
+// <0=> NRF_CLOCK_LF_ACCURACY_250_PPM
+// <1=> NRF_CLOCK_LF_ACCURACY_500_PPM
+// <2=> NRF_CLOCK_LF_ACCURACY_150_PPM
+// <3=> NRF_CLOCK_LF_ACCURACY_100_PPM
+// <4=> NRF_CLOCK_LF_ACCURACY_75_PPM
+// <5=> NRF_CLOCK_LF_ACCURACY_50_PPM
+// <6=> NRF_CLOCK_LF_ACCURACY_30_PPM
+// <7=> NRF_CLOCK_LF_ACCURACY_20_PPM
+// <8=> NRF_CLOCK_LF_ACCURACY_10_PPM
+// <9=> NRF_CLOCK_LF_ACCURACY_5_PPM
+// <10=> NRF_CLOCK_LF_ACCURACY_2_PPM
+// <11=> NRF_CLOCK_LF_ACCURACY_1_PPM
+
+#ifndef NRF_SDH_CLOCK_LF_ACCURACY
+#define NRF_SDH_CLOCK_LF_ACCURACY 7
+#endif
+
+// <o> NRF_SDH_SOC_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which SoC events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have SoC events dispatched before or after other stack events, such as ANT or BLE.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_SOC_STACK_OBSERVER_PRIO
+#define NRF_SDH_SOC_STACK_OBSERVER_PRIO 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> BLE Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_BLE_OBSERVER_PRIO_LEVELS - Total number of priority levels for BLE observers.
+// <i> This setting configures the number of priority levels available for BLE event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_BLE_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_BLE_OBSERVER_PRIO_LEVELS 4
+#endif
+
+// <h> BLE Observers priorities - Invididual priorities
+
+//==========================================================
+// <o> BLE_ADV_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Advertising module.
+
+#ifndef BLE_ADV_BLE_OBSERVER_PRIO
+#define BLE_ADV_BLE_OBSERVER_PRIO 1
+#endif
+
+// <o> BLE_CONN_STATE_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Connection State module.
+
+#ifndef BLE_CONN_STATE_BLE_OBSERVER_PRIO
+#define BLE_CONN_STATE_BLE_OBSERVER_PRIO 0
+#endif
+
+// <o> NRF_SDH_STACK_OBSERVER_PRIO_LEVELS - Total number of priority levels for stack event observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice stack event handlers (ANT, BLE, SoC).
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STACK_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_BLE_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which BLE events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have BLE events dispatched before or after other stack events, such as ANT or SoC.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_BLE_STACK_OBSERVER_PRIO
+#define NRF_SDH_BLE_STACK_OBSERVER_PRIO 0
+#endif
+
+//---
+
+// <e> NRF_BLE_QWR_ENABLED - nrf_ble_qwr - Queued writes support module (prepare/execute write)
+//==========================================================
+#ifndef NRF_BLE_QWR_ENABLED
+#define NRF_BLE_QWR_ENABLED 1
+#endif
+// <o> NRF_BLE_QWR_MAX_ATTR - Maximum number of attribute handles that can be registered. This number must be adjusted according to the number of attributes for which Queued Writes will be enabled. If it is zero, the module will reject all Queued Write requests.
+#ifndef NRF_BLE_QWR_MAX_ATTR
+#define NRF_BLE_QWR_MAX_ATTR 1
+#endif
+
+// <q> NRF_SECTION_ITER_ENABLED  - nrf_section_iter - Section iterator
+
+#ifndef NRF_SECTION_ITER_ENABLED
+#define NRF_SECTION_ITER_ENABLED 1
+#endif
+
+//---
+
+#ifndef BLE_BPS_ENABLED
+#define BLE_BPS_ENABLED 1
+#endif
+
+#endif // SDK_CONFIG_H

--- a/ci/libraries_tests/nrf5_ble_srv_cts_c/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_cts_c/CMakeLists.txt
@@ -1,0 +1,72 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# WARNING: FILE GENERATED FROM ./ci/scripts/generate_cmake_tests.sh SCRIPT.
+
+cmake_minimum_required(VERSION 3.14)
+project(nrf5_ble_srv_cts_c_test LANGUAGES C ASM)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../../cmake")
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME} "main.c")
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_balloc_fwd
+  nrf5_ble_common
+  nrf5_ble_db_discovery
+  nrf5_ble_srv_cts_c
+  nrf5_cli
+  nrf5_cli_fwd
+  nrf5_config
+  nrf5_delay
+  nrf5_ext_fprintf
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_log
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_memobj
+  nrf5_memobj_fwd
+  nrf5_mtx
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_pwr_mgmt
+  nrf5_queue
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+    nrf5_ble_gq
+  )
+endif()

--- a/ci/libraries_tests/nrf5_ble_srv_cts_c/main.c
+++ b/ci/libraries_tests/nrf5_ble_srv_cts_c/main.c
@@ -1,0 +1,13 @@
+#include "ble_cts_c.h"
+
+void app_error_handler_bare(uint32_t error_code)
+{
+}
+
+int main()
+{
+    ble_cts_c_t cts;
+    ble_cts_c_init_t cts_init;
+    ble_cts_c_init(&cts, &cts_init);
+    return 0;
+}

--- a/ci/libraries_tests/nrf5_ble_srv_cts_c/sdk_config.h
+++ b/ci/libraries_tests/nrf5_ble_srv_cts_c/sdk_config.h
@@ -1,0 +1,237 @@
+#ifndef SDK_CONFIG_H
+#define SDK_CONFIG_H
+
+#ifndef NRF_LOG_ENABLED
+#define NRF_LOG_ENABLED 0
+#endif
+
+// </h>
+//==========================================================
+
+// </h>
+//==========================================================
+
+// <h> nRF_SoftDevice
+
+//==========================================================
+// <e> NRF_SDH_BLE_ENABLED - nrf_sdh_ble - SoftDevice BLE event handler
+//==========================================================
+#ifndef NRF_SDH_BLE_ENABLED
+#define NRF_SDH_BLE_ENABLED 1
+#endif
+// <h> BLE Stack configuration - Stack configuration parameters
+
+// <i> The SoftDevice handler will configure the stack with these parameters when calling @ref nrf_sdh_ble_default_cfg_set.
+// <i> Other libraries might depend on these values; keep them up-to-date even if you are not explicitely calling @ref nrf_sdh_ble_default_cfg_set.
+//==========================================================
+// <o> NRF_SDH_BLE_GAP_DATA_LENGTH   <27-251>
+
+// <i> Requested BLE GAP data length to be negotiated.
+
+#ifndef NRF_SDH_BLE_GAP_DATA_LENGTH
+#define NRF_SDH_BLE_GAP_DATA_LENGTH 27
+#endif
+
+// <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links.
+#ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links.
+#ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count.
+// <i> Maximum number of total concurrent connections using the default configuration.
+
+#ifndef NRF_SDH_BLE_TOTAL_LINK_COUNT
+#define NRF_SDH_BLE_TOTAL_LINK_COUNT 1
+#endif
+
+// <o> NRF_SDH_BLE_GAP_EVENT_LENGTH - GAP event length.
+// <i> The time set aside for this connection on every connection interval in 1.25 ms units.
+
+#ifndef NRF_SDH_BLE_GAP_EVENT_LENGTH
+#define NRF_SDH_BLE_GAP_EVENT_LENGTH 6
+#endif
+
+// <o> NRF_SDH_BLE_GATT_MAX_MTU_SIZE - Static maximum MTU size.
+#ifndef NRF_SDH_BLE_GATT_MAX_MTU_SIZE
+#define NRF_SDH_BLE_GATT_MAX_MTU_SIZE 23
+#endif
+
+// <o> NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE - Attribute Table size in bytes. The size must be a multiple of 4.
+#ifndef NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE
+#define NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE 1408
+#endif
+
+// <o> NRF_SDH_BLE_VS_UUID_COUNT - The number of vendor-specific UUIDs.
+#ifndef NRF_SDH_BLE_VS_UUID_COUNT
+#define NRF_SDH_BLE_VS_UUID_COUNT 0
+#endif
+
+// <q> NRF_SDH_BLE_SERVICE_CHANGED  - Include the Service Changed characteristic in the Attribute Table.
+
+#ifndef NRF_SDH_BLE_SERVICE_CHANGED
+#define NRF_SDH_BLE_SERVICE_CHANGED 0
+#endif
+
+// <e> NRF_SDH_SOC_ENABLED - nrf_sdh_soc - SoftDevice SoC event handler
+//==========================================================
+#ifndef NRF_SDH_SOC_ENABLED
+#define NRF_SDH_SOC_ENABLED 1
+#endif
+// <h> SoC Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_SOC_OBSERVER_PRIO_LEVELS - Total number of priority levels for SoC observers.
+// <i> This setting configures the number of priority levels available for the SoC event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_SOC_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_SOC_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <h> SoC Observers priorities - Invididual priorities
+
+// <e> NRF_SDH_ENABLED - nrf_sdh - SoftDevice handler
+//==========================================================
+#ifndef NRF_SDH_ENABLED
+#define NRF_SDH_ENABLED 1
+#endif
+
+// </h>
+//==========================================================
+
+// <h> Clock - SoftDevice clock configuration
+
+//==========================================================
+// <o> NRF_SDH_CLOCK_LF_SRC  - SoftDevice clock source.
+
+// <0=> NRF_CLOCK_LF_SRC_RC
+// <1=> NRF_CLOCK_LF_SRC_XTAL
+// <2=> NRF_CLOCK_LF_SRC_SYNTH
+
+#ifndef NRF_SDH_CLOCK_LF_SRC
+#define NRF_SDH_CLOCK_LF_SRC 1
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_CTIV - SoftDevice calibration timer interval.
+#ifndef NRF_SDH_CLOCK_LF_RC_CTIV
+#define NRF_SDH_CLOCK_LF_RC_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_TEMP_CTIV - SoftDevice calibration timer interval under constant temperature.
+// <i> How often (in number of calibration intervals) the RC oscillator shall be calibrated
+// <i>  if the temperature has not changed.
+
+#ifndef NRF_SDH_CLOCK_LF_RC_TEMP_CTIV
+#define NRF_SDH_CLOCK_LF_RC_TEMP_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_ACCURACY  - External clock accuracy used in the LL to compute timing.
+
+// <0=> NRF_CLOCK_LF_ACCURACY_250_PPM
+// <1=> NRF_CLOCK_LF_ACCURACY_500_PPM
+// <2=> NRF_CLOCK_LF_ACCURACY_150_PPM
+// <3=> NRF_CLOCK_LF_ACCURACY_100_PPM
+// <4=> NRF_CLOCK_LF_ACCURACY_75_PPM
+// <5=> NRF_CLOCK_LF_ACCURACY_50_PPM
+// <6=> NRF_CLOCK_LF_ACCURACY_30_PPM
+// <7=> NRF_CLOCK_LF_ACCURACY_20_PPM
+// <8=> NRF_CLOCK_LF_ACCURACY_10_PPM
+// <9=> NRF_CLOCK_LF_ACCURACY_5_PPM
+// <10=> NRF_CLOCK_LF_ACCURACY_2_PPM
+// <11=> NRF_CLOCK_LF_ACCURACY_1_PPM
+
+#ifndef NRF_SDH_CLOCK_LF_ACCURACY
+#define NRF_SDH_CLOCK_LF_ACCURACY 7
+#endif
+
+// <o> NRF_SDH_SOC_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which SoC events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have SoC events dispatched before or after other stack events, such as ANT or BLE.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_SOC_STACK_OBSERVER_PRIO
+#define NRF_SDH_SOC_STACK_OBSERVER_PRIO 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> BLE Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_BLE_OBSERVER_PRIO_LEVELS - Total number of priority levels for BLE observers.
+// <i> This setting configures the number of priority levels available for BLE event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_BLE_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_BLE_OBSERVER_PRIO_LEVELS 4
+#endif
+
+// <h> BLE Observers priorities - Invididual priorities
+
+//==========================================================
+// <o> BLE_ADV_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Advertising module.
+
+#ifndef BLE_ADV_BLE_OBSERVER_PRIO
+#define BLE_ADV_BLE_OBSERVER_PRIO 1
+#endif
+
+// <o> BLE_CONN_STATE_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Connection State module.
+
+#ifndef BLE_CONN_STATE_BLE_OBSERVER_PRIO
+#define BLE_CONN_STATE_BLE_OBSERVER_PRIO 0
+#endif
+
+// <o> NRF_SDH_STACK_OBSERVER_PRIO_LEVELS - Total number of priority levels for stack event observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice stack event handlers (ANT, BLE, SoC).
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STACK_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_BLE_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which BLE events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have BLE events dispatched before or after other stack events, such as ANT or SoC.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_BLE_STACK_OBSERVER_PRIO
+#define NRF_SDH_BLE_STACK_OBSERVER_PRIO 0
+#endif
+
+//---
+
+// <e> NRF_BLE_QWR_ENABLED - nrf_ble_qwr - Queued writes support module (prepare/execute write)
+//==========================================================
+#ifndef NRF_BLE_QWR_ENABLED
+#define NRF_BLE_QWR_ENABLED 1
+#endif
+// <o> NRF_BLE_QWR_MAX_ATTR - Maximum number of attribute handles that can be registered. This number must be adjusted according to the number of attributes for which Queued Writes will be enabled. If it is zero, the module will reject all Queued Write requests.
+#ifndef NRF_BLE_QWR_MAX_ATTR
+#define NRF_BLE_QWR_MAX_ATTR 1
+#endif
+
+// <q> NRF_SECTION_ITER_ENABLED  - nrf_section_iter - Section iterator
+
+#ifndef NRF_SECTION_ITER_ENABLED
+#define NRF_SECTION_ITER_ENABLED 1
+#endif
+
+//---
+
+#ifndef BLE_CTS_C_ENABLED
+#define BLE_CTS_C_ENABLED 1
+#endif
+
+#ifndef BLE_DB_DISCOVERY_ENABLED
+#define BLE_DB_DISCOVERY_ENABLED 1
+#endif
+
+#endif // SDK_CONFIG_H

--- a/ci/libraries_tests/nrf5_ble_srv_gatts_c/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_gatts_c/CMakeLists.txt
@@ -1,0 +1,72 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# WARNING: FILE GENERATED FROM ./ci/scripts/generate_cmake_tests.sh SCRIPT.
+
+cmake_minimum_required(VERSION 3.14)
+project(nrf5_ble_srv_gatts_c_test LANGUAGES C ASM)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../../cmake")
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME} "main.c")
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_balloc_fwd
+  nrf5_ble_common
+  nrf5_ble_db_discovery
+  nrf5_ble_srv_gatts_c
+  nrf5_cli
+  nrf5_cli_fwd
+  nrf5_config
+  nrf5_delay
+  nrf5_ext_fprintf
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_log
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_memobj
+  nrf5_memobj_fwd
+  nrf5_mtx
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_pwr_mgmt
+  nrf5_queue
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+    nrf5_ble_gq
+  )
+endif()

--- a/ci/libraries_tests/nrf5_ble_srv_gatts_c/main.c
+++ b/ci/libraries_tests/nrf5_ble_srv_gatts_c/main.c
@@ -1,0 +1,13 @@
+#include "nrf_ble_gatts_c.h"
+
+void app_error_handler_bare(uint32_t error_code)
+{
+}
+
+int main()
+{
+    nrf_ble_gatts_c_t gatts;
+    nrf_ble_gatts_c_init_t gatts_init;
+    nrf_ble_gatts_c_init(&gatts, &gatts_init);
+    return 0;
+}

--- a/ci/libraries_tests/nrf5_ble_srv_gatts_c/sdk_config.h
+++ b/ci/libraries_tests/nrf5_ble_srv_gatts_c/sdk_config.h
@@ -1,0 +1,237 @@
+#ifndef SDK_CONFIG_H
+#define SDK_CONFIG_H
+
+#ifndef NRF_LOG_ENABLED
+#define NRF_LOG_ENABLED 0
+#endif
+
+// </h>
+//==========================================================
+
+// </h>
+//==========================================================
+
+// <h> nRF_SoftDevice
+
+//==========================================================
+// <e> NRF_SDH_BLE_ENABLED - nrf_sdh_ble - SoftDevice BLE event handler
+//==========================================================
+#ifndef NRF_SDH_BLE_ENABLED
+#define NRF_SDH_BLE_ENABLED 1
+#endif
+// <h> BLE Stack configuration - Stack configuration parameters
+
+// <i> The SoftDevice handler will configure the stack with these parameters when calling @ref nrf_sdh_ble_default_cfg_set.
+// <i> Other libraries might depend on these values; keep them up-to-date even if you are not explicitely calling @ref nrf_sdh_ble_default_cfg_set.
+//==========================================================
+// <o> NRF_SDH_BLE_GAP_DATA_LENGTH   <27-251>
+
+// <i> Requested BLE GAP data length to be negotiated.
+
+#ifndef NRF_SDH_BLE_GAP_DATA_LENGTH
+#define NRF_SDH_BLE_GAP_DATA_LENGTH 27
+#endif
+
+// <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links.
+#ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links.
+#ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count.
+// <i> Maximum number of total concurrent connections using the default configuration.
+
+#ifndef NRF_SDH_BLE_TOTAL_LINK_COUNT
+#define NRF_SDH_BLE_TOTAL_LINK_COUNT 1
+#endif
+
+// <o> NRF_SDH_BLE_GAP_EVENT_LENGTH - GAP event length.
+// <i> The time set aside for this connection on every connection interval in 1.25 ms units.
+
+#ifndef NRF_SDH_BLE_GAP_EVENT_LENGTH
+#define NRF_SDH_BLE_GAP_EVENT_LENGTH 6
+#endif
+
+// <o> NRF_SDH_BLE_GATT_MAX_MTU_SIZE - Static maximum MTU size.
+#ifndef NRF_SDH_BLE_GATT_MAX_MTU_SIZE
+#define NRF_SDH_BLE_GATT_MAX_MTU_SIZE 23
+#endif
+
+// <o> NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE - Attribute Table size in bytes. The size must be a multiple of 4.
+#ifndef NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE
+#define NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE 1408
+#endif
+
+// <o> NRF_SDH_BLE_VS_UUID_COUNT - The number of vendor-specific UUIDs.
+#ifndef NRF_SDH_BLE_VS_UUID_COUNT
+#define NRF_SDH_BLE_VS_UUID_COUNT 0
+#endif
+
+// <q> NRF_SDH_BLE_SERVICE_CHANGED  - Include the Service Changed characteristic in the Attribute Table.
+
+#ifndef NRF_SDH_BLE_SERVICE_CHANGED
+#define NRF_SDH_BLE_SERVICE_CHANGED 0
+#endif
+
+// <e> NRF_SDH_SOC_ENABLED - nrf_sdh_soc - SoftDevice SoC event handler
+//==========================================================
+#ifndef NRF_SDH_SOC_ENABLED
+#define NRF_SDH_SOC_ENABLED 1
+#endif
+// <h> SoC Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_SOC_OBSERVER_PRIO_LEVELS - Total number of priority levels for SoC observers.
+// <i> This setting configures the number of priority levels available for the SoC event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_SOC_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_SOC_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <h> SoC Observers priorities - Invididual priorities
+
+// <e> NRF_SDH_ENABLED - nrf_sdh - SoftDevice handler
+//==========================================================
+#ifndef NRF_SDH_ENABLED
+#define NRF_SDH_ENABLED 1
+#endif
+
+// </h>
+//==========================================================
+
+// <h> Clock - SoftDevice clock configuration
+
+//==========================================================
+// <o> NRF_SDH_CLOCK_LF_SRC  - SoftDevice clock source.
+
+// <0=> NRF_CLOCK_LF_SRC_RC
+// <1=> NRF_CLOCK_LF_SRC_XTAL
+// <2=> NRF_CLOCK_LF_SRC_SYNTH
+
+#ifndef NRF_SDH_CLOCK_LF_SRC
+#define NRF_SDH_CLOCK_LF_SRC 1
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_CTIV - SoftDevice calibration timer interval.
+#ifndef NRF_SDH_CLOCK_LF_RC_CTIV
+#define NRF_SDH_CLOCK_LF_RC_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_TEMP_CTIV - SoftDevice calibration timer interval under constant temperature.
+// <i> How often (in number of calibration intervals) the RC oscillator shall be calibrated
+// <i>  if the temperature has not changed.
+
+#ifndef NRF_SDH_CLOCK_LF_RC_TEMP_CTIV
+#define NRF_SDH_CLOCK_LF_RC_TEMP_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_ACCURACY  - External clock accuracy used in the LL to compute timing.
+
+// <0=> NRF_CLOCK_LF_ACCURACY_250_PPM
+// <1=> NRF_CLOCK_LF_ACCURACY_500_PPM
+// <2=> NRF_CLOCK_LF_ACCURACY_150_PPM
+// <3=> NRF_CLOCK_LF_ACCURACY_100_PPM
+// <4=> NRF_CLOCK_LF_ACCURACY_75_PPM
+// <5=> NRF_CLOCK_LF_ACCURACY_50_PPM
+// <6=> NRF_CLOCK_LF_ACCURACY_30_PPM
+// <7=> NRF_CLOCK_LF_ACCURACY_20_PPM
+// <8=> NRF_CLOCK_LF_ACCURACY_10_PPM
+// <9=> NRF_CLOCK_LF_ACCURACY_5_PPM
+// <10=> NRF_CLOCK_LF_ACCURACY_2_PPM
+// <11=> NRF_CLOCK_LF_ACCURACY_1_PPM
+
+#ifndef NRF_SDH_CLOCK_LF_ACCURACY
+#define NRF_SDH_CLOCK_LF_ACCURACY 7
+#endif
+
+// <o> NRF_SDH_SOC_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which SoC events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have SoC events dispatched before or after other stack events, such as ANT or BLE.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_SOC_STACK_OBSERVER_PRIO
+#define NRF_SDH_SOC_STACK_OBSERVER_PRIO 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> BLE Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_BLE_OBSERVER_PRIO_LEVELS - Total number of priority levels for BLE observers.
+// <i> This setting configures the number of priority levels available for BLE event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_BLE_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_BLE_OBSERVER_PRIO_LEVELS 4
+#endif
+
+// <h> BLE Observers priorities - Invididual priorities
+
+//==========================================================
+// <o> BLE_ADV_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Advertising module.
+
+#ifndef BLE_ADV_BLE_OBSERVER_PRIO
+#define BLE_ADV_BLE_OBSERVER_PRIO 1
+#endif
+
+// <o> BLE_CONN_STATE_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Connection State module.
+
+#ifndef BLE_CONN_STATE_BLE_OBSERVER_PRIO
+#define BLE_CONN_STATE_BLE_OBSERVER_PRIO 0
+#endif
+
+// <o> NRF_SDH_STACK_OBSERVER_PRIO_LEVELS - Total number of priority levels for stack event observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice stack event handlers (ANT, BLE, SoC).
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STACK_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_BLE_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which BLE events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have BLE events dispatched before or after other stack events, such as ANT or SoC.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_BLE_STACK_OBSERVER_PRIO
+#define NRF_SDH_BLE_STACK_OBSERVER_PRIO 0
+#endif
+
+//---
+
+// <e> NRF_BLE_QWR_ENABLED - nrf_ble_qwr - Queued writes support module (prepare/execute write)
+//==========================================================
+#ifndef NRF_BLE_QWR_ENABLED
+#define NRF_BLE_QWR_ENABLED 1
+#endif
+// <o> NRF_BLE_QWR_MAX_ATTR - Maximum number of attribute handles that can be registered. This number must be adjusted according to the number of attributes for which Queued Writes will be enabled. If it is zero, the module will reject all Queued Write requests.
+#ifndef NRF_BLE_QWR_MAX_ATTR
+#define NRF_BLE_QWR_MAX_ATTR 1
+#endif
+
+// <q> NRF_SECTION_ITER_ENABLED  - nrf_section_iter - Section iterator
+
+#ifndef NRF_SECTION_ITER_ENABLED
+#define NRF_SECTION_ITER_ENABLED 1
+#endif
+
+//---
+
+#ifndef NRF_BLE_GATTS_C_ENABLED
+#define NRF_BLE_GATTS_C_ENABLED 1
+#endif
+
+#ifndef BLE_DB_DISCOVERY_ENABLED
+#define BLE_DB_DISCOVERY_ENABLED 1
+#endif
+
+#endif // SDK_CONFIG_H

--- a/ci/libraries_tests/nrf5_ble_srv_hids/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_hids/CMakeLists.txt
@@ -1,0 +1,52 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# WARNING: FILE GENERATED FROM ./ci/scripts/generate_cmake_tests.sh SCRIPT.
+
+cmake_minimum_required(VERSION 3.14)
+project(nrf5_ble_srv_hids_test LANGUAGES C ASM)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../../cmake")
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME} "main.c")
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_link_ctx_manager
+  nrf5_ble_srv_hids
+  nrf5_config
+  nrf5_delay
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)

--- a/ci/libraries_tests/nrf5_ble_srv_hids/main.c
+++ b/ci/libraries_tests/nrf5_ble_srv_hids/main.c
@@ -1,0 +1,13 @@
+#include "ble_hids.h"
+
+void app_error_handler_bare(uint32_t error_code)
+{
+}
+
+int main()
+{
+    ble_hids_t hids;
+    ble_hids_init_t hids_init;
+    ble_hids_init(&hids, &hids_init);
+    return 0;
+}

--- a/ci/libraries_tests/nrf5_ble_srv_hids/sdk_config.h
+++ b/ci/libraries_tests/nrf5_ble_srv_hids/sdk_config.h
@@ -1,0 +1,233 @@
+#ifndef SDK_CONFIG_H
+#define SDK_CONFIG_H
+
+#ifndef NRF_LOG_ENABLED
+#define NRF_LOG_ENABLED 0
+#endif
+
+// </h>
+//==========================================================
+
+// </h>
+//==========================================================
+
+// <h> nRF_SoftDevice
+
+//==========================================================
+// <e> NRF_SDH_BLE_ENABLED - nrf_sdh_ble - SoftDevice BLE event handler
+//==========================================================
+#ifndef NRF_SDH_BLE_ENABLED
+#define NRF_SDH_BLE_ENABLED 1
+#endif
+// <h> BLE Stack configuration - Stack configuration parameters
+
+// <i> The SoftDevice handler will configure the stack with these parameters when calling @ref nrf_sdh_ble_default_cfg_set.
+// <i> Other libraries might depend on these values; keep them up-to-date even if you are not explicitely calling @ref nrf_sdh_ble_default_cfg_set.
+//==========================================================
+// <o> NRF_SDH_BLE_GAP_DATA_LENGTH   <27-251>
+
+// <i> Requested BLE GAP data length to be negotiated.
+
+#ifndef NRF_SDH_BLE_GAP_DATA_LENGTH
+#define NRF_SDH_BLE_GAP_DATA_LENGTH 27
+#endif
+
+// <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links.
+#ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links.
+#ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count.
+// <i> Maximum number of total concurrent connections using the default configuration.
+
+#ifndef NRF_SDH_BLE_TOTAL_LINK_COUNT
+#define NRF_SDH_BLE_TOTAL_LINK_COUNT 1
+#endif
+
+// <o> NRF_SDH_BLE_GAP_EVENT_LENGTH - GAP event length.
+// <i> The time set aside for this connection on every connection interval in 1.25 ms units.
+
+#ifndef NRF_SDH_BLE_GAP_EVENT_LENGTH
+#define NRF_SDH_BLE_GAP_EVENT_LENGTH 6
+#endif
+
+// <o> NRF_SDH_BLE_GATT_MAX_MTU_SIZE - Static maximum MTU size.
+#ifndef NRF_SDH_BLE_GATT_MAX_MTU_SIZE
+#define NRF_SDH_BLE_GATT_MAX_MTU_SIZE 23
+#endif
+
+// <o> NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE - Attribute Table size in bytes. The size must be a multiple of 4.
+#ifndef NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE
+#define NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE 1408
+#endif
+
+// <o> NRF_SDH_BLE_VS_UUID_COUNT - The number of vendor-specific UUIDs.
+#ifndef NRF_SDH_BLE_VS_UUID_COUNT
+#define NRF_SDH_BLE_VS_UUID_COUNT 0
+#endif
+
+// <q> NRF_SDH_BLE_SERVICE_CHANGED  - Include the Service Changed characteristic in the Attribute Table.
+
+#ifndef NRF_SDH_BLE_SERVICE_CHANGED
+#define NRF_SDH_BLE_SERVICE_CHANGED 0
+#endif
+
+// <e> NRF_SDH_SOC_ENABLED - nrf_sdh_soc - SoftDevice SoC event handler
+//==========================================================
+#ifndef NRF_SDH_SOC_ENABLED
+#define NRF_SDH_SOC_ENABLED 1
+#endif
+// <h> SoC Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_SOC_OBSERVER_PRIO_LEVELS - Total number of priority levels for SoC observers.
+// <i> This setting configures the number of priority levels available for the SoC event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_SOC_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_SOC_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <h> SoC Observers priorities - Invididual priorities
+
+// <e> NRF_SDH_ENABLED - nrf_sdh - SoftDevice handler
+//==========================================================
+#ifndef NRF_SDH_ENABLED
+#define NRF_SDH_ENABLED 1
+#endif
+
+// </h>
+//==========================================================
+
+// <h> Clock - SoftDevice clock configuration
+
+//==========================================================
+// <o> NRF_SDH_CLOCK_LF_SRC  - SoftDevice clock source.
+
+// <0=> NRF_CLOCK_LF_SRC_RC
+// <1=> NRF_CLOCK_LF_SRC_XTAL
+// <2=> NRF_CLOCK_LF_SRC_SYNTH
+
+#ifndef NRF_SDH_CLOCK_LF_SRC
+#define NRF_SDH_CLOCK_LF_SRC 1
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_CTIV - SoftDevice calibration timer interval.
+#ifndef NRF_SDH_CLOCK_LF_RC_CTIV
+#define NRF_SDH_CLOCK_LF_RC_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_TEMP_CTIV - SoftDevice calibration timer interval under constant temperature.
+// <i> How often (in number of calibration intervals) the RC oscillator shall be calibrated
+// <i>  if the temperature has not changed.
+
+#ifndef NRF_SDH_CLOCK_LF_RC_TEMP_CTIV
+#define NRF_SDH_CLOCK_LF_RC_TEMP_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_ACCURACY  - External clock accuracy used in the LL to compute timing.
+
+// <0=> NRF_CLOCK_LF_ACCURACY_250_PPM
+// <1=> NRF_CLOCK_LF_ACCURACY_500_PPM
+// <2=> NRF_CLOCK_LF_ACCURACY_150_PPM
+// <3=> NRF_CLOCK_LF_ACCURACY_100_PPM
+// <4=> NRF_CLOCK_LF_ACCURACY_75_PPM
+// <5=> NRF_CLOCK_LF_ACCURACY_50_PPM
+// <6=> NRF_CLOCK_LF_ACCURACY_30_PPM
+// <7=> NRF_CLOCK_LF_ACCURACY_20_PPM
+// <8=> NRF_CLOCK_LF_ACCURACY_10_PPM
+// <9=> NRF_CLOCK_LF_ACCURACY_5_PPM
+// <10=> NRF_CLOCK_LF_ACCURACY_2_PPM
+// <11=> NRF_CLOCK_LF_ACCURACY_1_PPM
+
+#ifndef NRF_SDH_CLOCK_LF_ACCURACY
+#define NRF_SDH_CLOCK_LF_ACCURACY 7
+#endif
+
+// <o> NRF_SDH_SOC_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which SoC events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have SoC events dispatched before or after other stack events, such as ANT or BLE.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_SOC_STACK_OBSERVER_PRIO
+#define NRF_SDH_SOC_STACK_OBSERVER_PRIO 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> BLE Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_BLE_OBSERVER_PRIO_LEVELS - Total number of priority levels for BLE observers.
+// <i> This setting configures the number of priority levels available for BLE event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_BLE_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_BLE_OBSERVER_PRIO_LEVELS 4
+#endif
+
+// <h> BLE Observers priorities - Invididual priorities
+
+//==========================================================
+// <o> BLE_ADV_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Advertising module.
+
+#ifndef BLE_ADV_BLE_OBSERVER_PRIO
+#define BLE_ADV_BLE_OBSERVER_PRIO 1
+#endif
+
+// <o> BLE_CONN_STATE_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Connection State module.
+
+#ifndef BLE_CONN_STATE_BLE_OBSERVER_PRIO
+#define BLE_CONN_STATE_BLE_OBSERVER_PRIO 0
+#endif
+
+// <o> NRF_SDH_STACK_OBSERVER_PRIO_LEVELS - Total number of priority levels for stack event observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice stack event handlers (ANT, BLE, SoC).
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STACK_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_BLE_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which BLE events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have BLE events dispatched before or after other stack events, such as ANT or SoC.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_BLE_STACK_OBSERVER_PRIO
+#define NRF_SDH_BLE_STACK_OBSERVER_PRIO 0
+#endif
+
+//---
+
+// <e> NRF_BLE_QWR_ENABLED - nrf_ble_qwr - Queued writes support module (prepare/execute write)
+//==========================================================
+#ifndef NRF_BLE_QWR_ENABLED
+#define NRF_BLE_QWR_ENABLED 1
+#endif
+// <o> NRF_BLE_QWR_MAX_ATTR - Maximum number of attribute handles that can be registered. This number must be adjusted according to the number of attributes for which Queued Writes will be enabled. If it is zero, the module will reject all Queued Write requests.
+#ifndef NRF_BLE_QWR_MAX_ATTR
+#define NRF_BLE_QWR_MAX_ATTR 1
+#endif
+
+// <q> NRF_SECTION_ITER_ENABLED  - nrf_section_iter - Section iterator
+
+#ifndef NRF_SECTION_ITER_ENABLED
+#define NRF_SECTION_ITER_ENABLED 1
+#endif
+
+//---
+
+#ifndef BLE_HIDS_ENABLED
+#define BLE_HIDS_ENABLED 1
+#endif
+
+#endif // SDK_CONFIG_H

--- a/ci/libraries_tests/nrf5_ble_srv_hts/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_hts/CMakeLists.txt
@@ -1,0 +1,63 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# WARNING: FILE GENERATED FROM ./ci/scripts/generate_cmake_tests.sh SCRIPT.
+
+cmake_minimum_required(VERSION 3.14)
+project(nrf5_ble_srv_hts_test LANGUAGES C ASM)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../../cmake")
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME} "main.c")
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_srv_hts
+  nrf5_config
+  nrf5_delay
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+    nrf5_balloc
+    nrf5_balloc_fwd
+    nrf5_ble_gq
+    nrf5_cli_fwd
+    nrf5_ext_fprintf
+    nrf5_memobj
+    nrf5_memobj_fwd
+    nrf5_queue
+  )
+endif()

--- a/ci/libraries_tests/nrf5_ble_srv_hts/main.c
+++ b/ci/libraries_tests/nrf5_ble_srv_hts/main.c
@@ -1,0 +1,13 @@
+#include "ble_hts.h"
+
+void app_error_handler_bare(uint32_t error_code)
+{
+}
+
+int main()
+{
+    ble_hts_t hts;
+    ble_hts_init_t hts_init;
+    ble_hts_init(&hts, &hts_init);
+    return 0;
+}

--- a/ci/libraries_tests/nrf5_ble_srv_hts/sdk_config.h
+++ b/ci/libraries_tests/nrf5_ble_srv_hts/sdk_config.h
@@ -1,0 +1,233 @@
+#ifndef SDK_CONFIG_H
+#define SDK_CONFIG_H
+
+#ifndef NRF_LOG_ENABLED
+#define NRF_LOG_ENABLED 0
+#endif
+
+// </h>
+//==========================================================
+
+// </h>
+//==========================================================
+
+// <h> nRF_SoftDevice
+
+//==========================================================
+// <e> NRF_SDH_BLE_ENABLED - nrf_sdh_ble - SoftDevice BLE event handler
+//==========================================================
+#ifndef NRF_SDH_BLE_ENABLED
+#define NRF_SDH_BLE_ENABLED 1
+#endif
+// <h> BLE Stack configuration - Stack configuration parameters
+
+// <i> The SoftDevice handler will configure the stack with these parameters when calling @ref nrf_sdh_ble_default_cfg_set.
+// <i> Other libraries might depend on these values; keep them up-to-date even if you are not explicitely calling @ref nrf_sdh_ble_default_cfg_set.
+//==========================================================
+// <o> NRF_SDH_BLE_GAP_DATA_LENGTH   <27-251>
+
+// <i> Requested BLE GAP data length to be negotiated.
+
+#ifndef NRF_SDH_BLE_GAP_DATA_LENGTH
+#define NRF_SDH_BLE_GAP_DATA_LENGTH 27
+#endif
+
+// <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links.
+#ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links.
+#ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count.
+// <i> Maximum number of total concurrent connections using the default configuration.
+
+#ifndef NRF_SDH_BLE_TOTAL_LINK_COUNT
+#define NRF_SDH_BLE_TOTAL_LINK_COUNT 1
+#endif
+
+// <o> NRF_SDH_BLE_GAP_EVENT_LENGTH - GAP event length.
+// <i> The time set aside for this connection on every connection interval in 1.25 ms units.
+
+#ifndef NRF_SDH_BLE_GAP_EVENT_LENGTH
+#define NRF_SDH_BLE_GAP_EVENT_LENGTH 6
+#endif
+
+// <o> NRF_SDH_BLE_GATT_MAX_MTU_SIZE - Static maximum MTU size.
+#ifndef NRF_SDH_BLE_GATT_MAX_MTU_SIZE
+#define NRF_SDH_BLE_GATT_MAX_MTU_SIZE 23
+#endif
+
+// <o> NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE - Attribute Table size in bytes. The size must be a multiple of 4.
+#ifndef NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE
+#define NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE 1408
+#endif
+
+// <o> NRF_SDH_BLE_VS_UUID_COUNT - The number of vendor-specific UUIDs.
+#ifndef NRF_SDH_BLE_VS_UUID_COUNT
+#define NRF_SDH_BLE_VS_UUID_COUNT 0
+#endif
+
+// <q> NRF_SDH_BLE_SERVICE_CHANGED  - Include the Service Changed characteristic in the Attribute Table.
+
+#ifndef NRF_SDH_BLE_SERVICE_CHANGED
+#define NRF_SDH_BLE_SERVICE_CHANGED 0
+#endif
+
+// <e> NRF_SDH_SOC_ENABLED - nrf_sdh_soc - SoftDevice SoC event handler
+//==========================================================
+#ifndef NRF_SDH_SOC_ENABLED
+#define NRF_SDH_SOC_ENABLED 1
+#endif
+// <h> SoC Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_SOC_OBSERVER_PRIO_LEVELS - Total number of priority levels for SoC observers.
+// <i> This setting configures the number of priority levels available for the SoC event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_SOC_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_SOC_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <h> SoC Observers priorities - Invididual priorities
+
+// <e> NRF_SDH_ENABLED - nrf_sdh - SoftDevice handler
+//==========================================================
+#ifndef NRF_SDH_ENABLED
+#define NRF_SDH_ENABLED 1
+#endif
+
+// </h>
+//==========================================================
+
+// <h> Clock - SoftDevice clock configuration
+
+//==========================================================
+// <o> NRF_SDH_CLOCK_LF_SRC  - SoftDevice clock source.
+
+// <0=> NRF_CLOCK_LF_SRC_RC
+// <1=> NRF_CLOCK_LF_SRC_XTAL
+// <2=> NRF_CLOCK_LF_SRC_SYNTH
+
+#ifndef NRF_SDH_CLOCK_LF_SRC
+#define NRF_SDH_CLOCK_LF_SRC 1
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_CTIV - SoftDevice calibration timer interval.
+#ifndef NRF_SDH_CLOCK_LF_RC_CTIV
+#define NRF_SDH_CLOCK_LF_RC_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_TEMP_CTIV - SoftDevice calibration timer interval under constant temperature.
+// <i> How often (in number of calibration intervals) the RC oscillator shall be calibrated
+// <i>  if the temperature has not changed.
+
+#ifndef NRF_SDH_CLOCK_LF_RC_TEMP_CTIV
+#define NRF_SDH_CLOCK_LF_RC_TEMP_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_ACCURACY  - External clock accuracy used in the LL to compute timing.
+
+// <0=> NRF_CLOCK_LF_ACCURACY_250_PPM
+// <1=> NRF_CLOCK_LF_ACCURACY_500_PPM
+// <2=> NRF_CLOCK_LF_ACCURACY_150_PPM
+// <3=> NRF_CLOCK_LF_ACCURACY_100_PPM
+// <4=> NRF_CLOCK_LF_ACCURACY_75_PPM
+// <5=> NRF_CLOCK_LF_ACCURACY_50_PPM
+// <6=> NRF_CLOCK_LF_ACCURACY_30_PPM
+// <7=> NRF_CLOCK_LF_ACCURACY_20_PPM
+// <8=> NRF_CLOCK_LF_ACCURACY_10_PPM
+// <9=> NRF_CLOCK_LF_ACCURACY_5_PPM
+// <10=> NRF_CLOCK_LF_ACCURACY_2_PPM
+// <11=> NRF_CLOCK_LF_ACCURACY_1_PPM
+
+#ifndef NRF_SDH_CLOCK_LF_ACCURACY
+#define NRF_SDH_CLOCK_LF_ACCURACY 7
+#endif
+
+// <o> NRF_SDH_SOC_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which SoC events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have SoC events dispatched before or after other stack events, such as ANT or BLE.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_SOC_STACK_OBSERVER_PRIO
+#define NRF_SDH_SOC_STACK_OBSERVER_PRIO 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> BLE Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_BLE_OBSERVER_PRIO_LEVELS - Total number of priority levels for BLE observers.
+// <i> This setting configures the number of priority levels available for BLE event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_BLE_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_BLE_OBSERVER_PRIO_LEVELS 4
+#endif
+
+// <h> BLE Observers priorities - Invididual priorities
+
+//==========================================================
+// <o> BLE_ADV_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Advertising module.
+
+#ifndef BLE_ADV_BLE_OBSERVER_PRIO
+#define BLE_ADV_BLE_OBSERVER_PRIO 1
+#endif
+
+// <o> BLE_CONN_STATE_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Connection State module.
+
+#ifndef BLE_CONN_STATE_BLE_OBSERVER_PRIO
+#define BLE_CONN_STATE_BLE_OBSERVER_PRIO 0
+#endif
+
+// <o> NRF_SDH_STACK_OBSERVER_PRIO_LEVELS - Total number of priority levels for stack event observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice stack event handlers (ANT, BLE, SoC).
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STACK_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_BLE_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which BLE events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have BLE events dispatched before or after other stack events, such as ANT or SoC.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_BLE_STACK_OBSERVER_PRIO
+#define NRF_SDH_BLE_STACK_OBSERVER_PRIO 0
+#endif
+
+//---
+
+// <e> NRF_BLE_QWR_ENABLED - nrf_ble_qwr - Queued writes support module (prepare/execute write)
+//==========================================================
+#ifndef NRF_BLE_QWR_ENABLED
+#define NRF_BLE_QWR_ENABLED 1
+#endif
+// <o> NRF_BLE_QWR_MAX_ATTR - Maximum number of attribute handles that can be registered. This number must be adjusted according to the number of attributes for which Queued Writes will be enabled. If it is zero, the module will reject all Queued Write requests.
+#ifndef NRF_BLE_QWR_MAX_ATTR
+#define NRF_BLE_QWR_MAX_ATTR 1
+#endif
+
+// <q> NRF_SECTION_ITER_ENABLED  - nrf_section_iter - Section iterator
+
+#ifndef NRF_SECTION_ITER_ENABLED
+#define NRF_SECTION_ITER_ENABLED 1
+#endif
+
+//---
+
+#ifndef BLE_HTS_ENABLED
+#define BLE_HTS_ENABLED 1
+#endif
+
+#endif // SDK_CONFIG_H

--- a/ci/libraries_tests/nrf5_ble_srv_lns/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_lns/CMakeLists.txt
@@ -1,0 +1,63 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# WARNING: FILE GENERATED FROM ./ci/scripts/generate_cmake_tests.sh SCRIPT.
+
+cmake_minimum_required(VERSION 3.14)
+project(nrf5_ble_srv_lns_test LANGUAGES C ASM)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../../cmake")
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME} "main.c")
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_srv_lns
+  nrf5_config
+  nrf5_delay
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+    nrf5_balloc
+    nrf5_balloc_fwd
+    nrf5_ble_gq
+    nrf5_cli_fwd
+    nrf5_ext_fprintf
+    nrf5_memobj
+    nrf5_memobj_fwd
+    nrf5_queue
+  )
+endif()

--- a/ci/libraries_tests/nrf5_ble_srv_lns/main.c
+++ b/ci/libraries_tests/nrf5_ble_srv_lns/main.c
@@ -1,0 +1,13 @@
+#include "ble_lns.h"
+
+void app_error_handler_bare(uint32_t error_code)
+{
+}
+
+int main()
+{
+    ble_lns_t lns;
+    ble_lns_init_t lns_init;
+    ble_lns_init(&lns, &lns_init);
+    return 0;
+}

--- a/ci/libraries_tests/nrf5_ble_srv_lns/sdk_config.h
+++ b/ci/libraries_tests/nrf5_ble_srv_lns/sdk_config.h
@@ -1,0 +1,229 @@
+#ifndef SDK_CONFIG_H
+#define SDK_CONFIG_H
+
+#ifndef NRF_LOG_ENABLED
+#define NRF_LOG_ENABLED 0
+#endif
+
+// </h>
+//==========================================================
+
+// </h>
+//==========================================================
+
+// <h> nRF_SoftDevice
+
+//==========================================================
+// <e> NRF_SDH_BLE_ENABLED - nrf_sdh_ble - SoftDevice BLE event handler
+//==========================================================
+#ifndef NRF_SDH_BLE_ENABLED
+#define NRF_SDH_BLE_ENABLED 1
+#endif
+// <h> BLE Stack configuration - Stack configuration parameters
+
+// <i> The SoftDevice handler will configure the stack with these parameters when calling @ref nrf_sdh_ble_default_cfg_set.
+// <i> Other libraries might depend on these values; keep them up-to-date even if you are not explicitely calling @ref nrf_sdh_ble_default_cfg_set.
+//==========================================================
+// <o> NRF_SDH_BLE_GAP_DATA_LENGTH   <27-251>
+
+// <i> Requested BLE GAP data length to be negotiated.
+
+#ifndef NRF_SDH_BLE_GAP_DATA_LENGTH
+#define NRF_SDH_BLE_GAP_DATA_LENGTH 27
+#endif
+
+// <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links.
+#ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links.
+#ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count.
+// <i> Maximum number of total concurrent connections using the default configuration.
+
+#ifndef NRF_SDH_BLE_TOTAL_LINK_COUNT
+#define NRF_SDH_BLE_TOTAL_LINK_COUNT 1
+#endif
+
+// <o> NRF_SDH_BLE_GAP_EVENT_LENGTH - GAP event length.
+// <i> The time set aside for this connection on every connection interval in 1.25 ms units.
+
+#ifndef NRF_SDH_BLE_GAP_EVENT_LENGTH
+#define NRF_SDH_BLE_GAP_EVENT_LENGTH 6
+#endif
+
+// <o> NRF_SDH_BLE_GATT_MAX_MTU_SIZE - Static maximum MTU size.
+#ifndef NRF_SDH_BLE_GATT_MAX_MTU_SIZE
+#define NRF_SDH_BLE_GATT_MAX_MTU_SIZE 23
+#endif
+
+// <o> NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE - Attribute Table size in bytes. The size must be a multiple of 4.
+#ifndef NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE
+#define NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE 1408
+#endif
+
+// <o> NRF_SDH_BLE_VS_UUID_COUNT - The number of vendor-specific UUIDs.
+#ifndef NRF_SDH_BLE_VS_UUID_COUNT
+#define NRF_SDH_BLE_VS_UUID_COUNT 0
+#endif
+
+// <q> NRF_SDH_BLE_SERVICE_CHANGED  - Include the Service Changed characteristic in the Attribute Table.
+
+#ifndef NRF_SDH_BLE_SERVICE_CHANGED
+#define NRF_SDH_BLE_SERVICE_CHANGED 0
+#endif
+
+// <e> NRF_SDH_SOC_ENABLED - nrf_sdh_soc - SoftDevice SoC event handler
+//==========================================================
+#ifndef NRF_SDH_SOC_ENABLED
+#define NRF_SDH_SOC_ENABLED 1
+#endif
+// <h> SoC Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_SOC_OBSERVER_PRIO_LEVELS - Total number of priority levels for SoC observers.
+// <i> This setting configures the number of priority levels available for the SoC event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_SOC_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_SOC_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <h> SoC Observers priorities - Invididual priorities
+
+// <e> NRF_SDH_ENABLED - nrf_sdh - SoftDevice handler
+//==========================================================
+#ifndef NRF_SDH_ENABLED
+#define NRF_SDH_ENABLED 1
+#endif
+
+// </h>
+//==========================================================
+
+// <h> Clock - SoftDevice clock configuration
+
+//==========================================================
+// <o> NRF_SDH_CLOCK_LF_SRC  - SoftDevice clock source.
+
+// <0=> NRF_CLOCK_LF_SRC_RC
+// <1=> NRF_CLOCK_LF_SRC_XTAL
+// <2=> NRF_CLOCK_LF_SRC_SYNTH
+
+#ifndef NRF_SDH_CLOCK_LF_SRC
+#define NRF_SDH_CLOCK_LF_SRC 1
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_CTIV - SoftDevice calibration timer interval.
+#ifndef NRF_SDH_CLOCK_LF_RC_CTIV
+#define NRF_SDH_CLOCK_LF_RC_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_TEMP_CTIV - SoftDevice calibration timer interval under constant temperature.
+// <i> How often (in number of calibration intervals) the RC oscillator shall be calibrated
+// <i>  if the temperature has not changed.
+
+#ifndef NRF_SDH_CLOCK_LF_RC_TEMP_CTIV
+#define NRF_SDH_CLOCK_LF_RC_TEMP_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_ACCURACY  - External clock accuracy used in the LL to compute timing.
+
+// <0=> NRF_CLOCK_LF_ACCURACY_250_PPM
+// <1=> NRF_CLOCK_LF_ACCURACY_500_PPM
+// <2=> NRF_CLOCK_LF_ACCURACY_150_PPM
+// <3=> NRF_CLOCK_LF_ACCURACY_100_PPM
+// <4=> NRF_CLOCK_LF_ACCURACY_75_PPM
+// <5=> NRF_CLOCK_LF_ACCURACY_50_PPM
+// <6=> NRF_CLOCK_LF_ACCURACY_30_PPM
+// <7=> NRF_CLOCK_LF_ACCURACY_20_PPM
+// <8=> NRF_CLOCK_LF_ACCURACY_10_PPM
+// <9=> NRF_CLOCK_LF_ACCURACY_5_PPM
+// <10=> NRF_CLOCK_LF_ACCURACY_2_PPM
+// <11=> NRF_CLOCK_LF_ACCURACY_1_PPM
+
+#ifndef NRF_SDH_CLOCK_LF_ACCURACY
+#define NRF_SDH_CLOCK_LF_ACCURACY 7
+#endif
+
+// <o> NRF_SDH_SOC_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which SoC events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have SoC events dispatched before or after other stack events, such as ANT or BLE.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_SOC_STACK_OBSERVER_PRIO
+#define NRF_SDH_SOC_STACK_OBSERVER_PRIO 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> BLE Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_BLE_OBSERVER_PRIO_LEVELS - Total number of priority levels for BLE observers.
+// <i> This setting configures the number of priority levels available for BLE event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_BLE_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_BLE_OBSERVER_PRIO_LEVELS 4
+#endif
+
+// <h> BLE Observers priorities - Invididual priorities
+
+//==========================================================
+// <o> BLE_ADV_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Advertising module.
+
+#ifndef BLE_ADV_BLE_OBSERVER_PRIO
+#define BLE_ADV_BLE_OBSERVER_PRIO 1
+#endif
+
+// <o> BLE_CONN_STATE_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Connection State module.
+
+#ifndef BLE_CONN_STATE_BLE_OBSERVER_PRIO
+#define BLE_CONN_STATE_BLE_OBSERVER_PRIO 0
+#endif
+
+// <o> NRF_SDH_STACK_OBSERVER_PRIO_LEVELS - Total number of priority levels for stack event observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice stack event handlers (ANT, BLE, SoC).
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STACK_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_BLE_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which BLE events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have BLE events dispatched before or after other stack events, such as ANT or SoC.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_BLE_STACK_OBSERVER_PRIO
+#define NRF_SDH_BLE_STACK_OBSERVER_PRIO 0
+#endif
+
+//---
+
+// <e> NRF_BLE_QWR_ENABLED - nrf_ble_qwr - Queued writes support module (prepare/execute write)
+//==========================================================
+#ifndef NRF_BLE_QWR_ENABLED
+#define NRF_BLE_QWR_ENABLED 1
+#endif
+// <o> NRF_BLE_QWR_MAX_ATTR - Maximum number of attribute handles that can be registered. This number must be adjusted according to the number of attributes for which Queued Writes will be enabled. If it is zero, the module will reject all Queued Write requests.
+#ifndef NRF_BLE_QWR_MAX_ATTR
+#define NRF_BLE_QWR_MAX_ATTR 1
+#endif
+
+// <q> NRF_SECTION_ITER_ENABLED  - nrf_section_iter - Section iterator
+
+#ifndef NRF_SECTION_ITER_ENABLED
+#define NRF_SECTION_ITER_ENABLED 1
+#endif
+
+//---
+
+#endif // SDK_CONFIG_H

--- a/ci/libraries_tests/nrf5_ble_srv_rscs/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_rscs/CMakeLists.txt
@@ -1,0 +1,51 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# WARNING: FILE GENERATED FROM ./ci/scripts/generate_cmake_tests.sh SCRIPT.
+
+cmake_minimum_required(VERSION 3.14)
+project(nrf5_ble_srv_rscs_test LANGUAGES C ASM)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../../cmake")
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME} "main.c")
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_srv_rscs
+  nrf5_config
+  nrf5_delay
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)

--- a/ci/libraries_tests/nrf5_ble_srv_rscs/main.c
+++ b/ci/libraries_tests/nrf5_ble_srv_rscs/main.c
@@ -1,0 +1,13 @@
+#include "ble_rscs.h"
+
+void app_error_handler_bare(uint32_t error_code)
+{
+}
+
+int main()
+{
+    ble_rscs_t rscs;
+    ble_rscs_init_t rscs_init;
+    ble_rscs_init(&rscs, &rscs_init);
+    return 0;
+}

--- a/ci/libraries_tests/nrf5_ble_srv_rscs/sdk_config.h
+++ b/ci/libraries_tests/nrf5_ble_srv_rscs/sdk_config.h
@@ -1,0 +1,233 @@
+#ifndef SDK_CONFIG_H
+#define SDK_CONFIG_H
+
+#ifndef NRF_LOG_ENABLED
+#define NRF_LOG_ENABLED 0
+#endif
+
+// </h>
+//==========================================================
+
+// </h>
+//==========================================================
+
+// <h> nRF_SoftDevice
+
+//==========================================================
+// <e> NRF_SDH_BLE_ENABLED - nrf_sdh_ble - SoftDevice BLE event handler
+//==========================================================
+#ifndef NRF_SDH_BLE_ENABLED
+#define NRF_SDH_BLE_ENABLED 1
+#endif
+// <h> BLE Stack configuration - Stack configuration parameters
+
+// <i> The SoftDevice handler will configure the stack with these parameters when calling @ref nrf_sdh_ble_default_cfg_set.
+// <i> Other libraries might depend on these values; keep them up-to-date even if you are not explicitely calling @ref nrf_sdh_ble_default_cfg_set.
+//==========================================================
+// <o> NRF_SDH_BLE_GAP_DATA_LENGTH   <27-251>
+
+// <i> Requested BLE GAP data length to be negotiated.
+
+#ifndef NRF_SDH_BLE_GAP_DATA_LENGTH
+#define NRF_SDH_BLE_GAP_DATA_LENGTH 27
+#endif
+
+// <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links.
+#ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links.
+#ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count.
+// <i> Maximum number of total concurrent connections using the default configuration.
+
+#ifndef NRF_SDH_BLE_TOTAL_LINK_COUNT
+#define NRF_SDH_BLE_TOTAL_LINK_COUNT 1
+#endif
+
+// <o> NRF_SDH_BLE_GAP_EVENT_LENGTH - GAP event length.
+// <i> The time set aside for this connection on every connection interval in 1.25 ms units.
+
+#ifndef NRF_SDH_BLE_GAP_EVENT_LENGTH
+#define NRF_SDH_BLE_GAP_EVENT_LENGTH 6
+#endif
+
+// <o> NRF_SDH_BLE_GATT_MAX_MTU_SIZE - Static maximum MTU size.
+#ifndef NRF_SDH_BLE_GATT_MAX_MTU_SIZE
+#define NRF_SDH_BLE_GATT_MAX_MTU_SIZE 23
+#endif
+
+// <o> NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE - Attribute Table size in bytes. The size must be a multiple of 4.
+#ifndef NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE
+#define NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE 1408
+#endif
+
+// <o> NRF_SDH_BLE_VS_UUID_COUNT - The number of vendor-specific UUIDs.
+#ifndef NRF_SDH_BLE_VS_UUID_COUNT
+#define NRF_SDH_BLE_VS_UUID_COUNT 0
+#endif
+
+// <q> NRF_SDH_BLE_SERVICE_CHANGED  - Include the Service Changed characteristic in the Attribute Table.
+
+#ifndef NRF_SDH_BLE_SERVICE_CHANGED
+#define NRF_SDH_BLE_SERVICE_CHANGED 0
+#endif
+
+// <e> NRF_SDH_SOC_ENABLED - nrf_sdh_soc - SoftDevice SoC event handler
+//==========================================================
+#ifndef NRF_SDH_SOC_ENABLED
+#define NRF_SDH_SOC_ENABLED 1
+#endif
+// <h> SoC Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_SOC_OBSERVER_PRIO_LEVELS - Total number of priority levels for SoC observers.
+// <i> This setting configures the number of priority levels available for the SoC event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_SOC_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_SOC_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <h> SoC Observers priorities - Invididual priorities
+
+// <e> NRF_SDH_ENABLED - nrf_sdh - SoftDevice handler
+//==========================================================
+#ifndef NRF_SDH_ENABLED
+#define NRF_SDH_ENABLED 1
+#endif
+
+// </h>
+//==========================================================
+
+// <h> Clock - SoftDevice clock configuration
+
+//==========================================================
+// <o> NRF_SDH_CLOCK_LF_SRC  - SoftDevice clock source.
+
+// <0=> NRF_CLOCK_LF_SRC_RC
+// <1=> NRF_CLOCK_LF_SRC_XTAL
+// <2=> NRF_CLOCK_LF_SRC_SYNTH
+
+#ifndef NRF_SDH_CLOCK_LF_SRC
+#define NRF_SDH_CLOCK_LF_SRC 1
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_CTIV - SoftDevice calibration timer interval.
+#ifndef NRF_SDH_CLOCK_LF_RC_CTIV
+#define NRF_SDH_CLOCK_LF_RC_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_TEMP_CTIV - SoftDevice calibration timer interval under constant temperature.
+// <i> How often (in number of calibration intervals) the RC oscillator shall be calibrated
+// <i>  if the temperature has not changed.
+
+#ifndef NRF_SDH_CLOCK_LF_RC_TEMP_CTIV
+#define NRF_SDH_CLOCK_LF_RC_TEMP_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_ACCURACY  - External clock accuracy used in the LL to compute timing.
+
+// <0=> NRF_CLOCK_LF_ACCURACY_250_PPM
+// <1=> NRF_CLOCK_LF_ACCURACY_500_PPM
+// <2=> NRF_CLOCK_LF_ACCURACY_150_PPM
+// <3=> NRF_CLOCK_LF_ACCURACY_100_PPM
+// <4=> NRF_CLOCK_LF_ACCURACY_75_PPM
+// <5=> NRF_CLOCK_LF_ACCURACY_50_PPM
+// <6=> NRF_CLOCK_LF_ACCURACY_30_PPM
+// <7=> NRF_CLOCK_LF_ACCURACY_20_PPM
+// <8=> NRF_CLOCK_LF_ACCURACY_10_PPM
+// <9=> NRF_CLOCK_LF_ACCURACY_5_PPM
+// <10=> NRF_CLOCK_LF_ACCURACY_2_PPM
+// <11=> NRF_CLOCK_LF_ACCURACY_1_PPM
+
+#ifndef NRF_SDH_CLOCK_LF_ACCURACY
+#define NRF_SDH_CLOCK_LF_ACCURACY 7
+#endif
+
+// <o> NRF_SDH_SOC_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which SoC events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have SoC events dispatched before or after other stack events, such as ANT or BLE.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_SOC_STACK_OBSERVER_PRIO
+#define NRF_SDH_SOC_STACK_OBSERVER_PRIO 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> BLE Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_BLE_OBSERVER_PRIO_LEVELS - Total number of priority levels for BLE observers.
+// <i> This setting configures the number of priority levels available for BLE event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_BLE_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_BLE_OBSERVER_PRIO_LEVELS 4
+#endif
+
+// <h> BLE Observers priorities - Invididual priorities
+
+//==========================================================
+// <o> BLE_ADV_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Advertising module.
+
+#ifndef BLE_ADV_BLE_OBSERVER_PRIO
+#define BLE_ADV_BLE_OBSERVER_PRIO 1
+#endif
+
+// <o> BLE_CONN_STATE_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Connection State module.
+
+#ifndef BLE_CONN_STATE_BLE_OBSERVER_PRIO
+#define BLE_CONN_STATE_BLE_OBSERVER_PRIO 0
+#endif
+
+// <o> NRF_SDH_STACK_OBSERVER_PRIO_LEVELS - Total number of priority levels for stack event observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice stack event handlers (ANT, BLE, SoC).
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STACK_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_BLE_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which BLE events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have BLE events dispatched before or after other stack events, such as ANT or SoC.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_BLE_STACK_OBSERVER_PRIO
+#define NRF_SDH_BLE_STACK_OBSERVER_PRIO 0
+#endif
+
+//---
+
+// <e> NRF_BLE_QWR_ENABLED - nrf_ble_qwr - Queued writes support module (prepare/execute write)
+//==========================================================
+#ifndef NRF_BLE_QWR_ENABLED
+#define NRF_BLE_QWR_ENABLED 1
+#endif
+// <o> NRF_BLE_QWR_MAX_ATTR - Maximum number of attribute handles that can be registered. This number must be adjusted according to the number of attributes for which Queued Writes will be enabled. If it is zero, the module will reject all Queued Write requests.
+#ifndef NRF_BLE_QWR_MAX_ATTR
+#define NRF_BLE_QWR_MAX_ATTR 1
+#endif
+
+// <q> NRF_SECTION_ITER_ENABLED  - nrf_section_iter - Section iterator
+
+#ifndef NRF_SECTION_ITER_ENABLED
+#define NRF_SECTION_ITER_ENABLED 1
+#endif
+
+//---
+
+#ifndef BLE_RSCS_ENABLED
+#define BLE_RSCS_ENABLED 1
+#endif
+
+#endif // SDK_CONFIG_H

--- a/ci/libraries_tests/nrf5_cli/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_cli/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atomic
   nrf5_balloc

--- a/ci/libraries_tests/nrf5_cli_cdc_acm/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_cli_cdc_acm/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_usbd_cdc_acm
   nrf5_app_util_platform

--- a/ci/libraries_tests/nrf5_crypto/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_crypto/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_crypto_cc310_backend/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_crypto_cc310_backend/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_crypto_cc310_bl_backend/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_crypto_cc310_bl_backend/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_crypto_cifra_backend/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_crypto_cifra_backend/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_crypto_mbedtls_backend/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_crypto_mbedtls_backend/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_crypto_micro_ecc_backend/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_crypto_micro_ecc_backend/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   micro_ecc
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_crypto_nrf_hw_backend/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_crypto_nrf_hw_backend/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_crypto_nrf_sw_backend/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_crypto_nrf_sw_backend/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_crypto_oberon_backend/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_crypto_oberon_backend/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_crypto_optiga_backend/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_crypto_optiga_backend/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_drv_power/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_drv_power/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_drv_rng/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_drv_rng/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_drv_spi/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_drv_spi/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_drv_spis/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_drv_spis/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_drv_twi/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_drv_twi/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_drv_uart/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_drv_uart/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_ext_optiga/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ext_optiga/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_fds/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_fds/CMakeLists.txt
@@ -33,6 +33,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_fstorage_sd/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_fstorage_sd/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_gfx/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_gfx/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_hardfault/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_hardfault/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_log/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_log/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_log_backend_flash/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_log_backend_flash/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_log_backend_rtt/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_log_backend_rtt/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_log_backend_serial/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_log_backend_serial/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_log_backend_uart/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_log_backend_uart/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_log_default_backends/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_log_default_backends/CMakeLists.txt
@@ -33,6 +33,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_mpu/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_mpu/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_nrfx_clock/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_clock/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_nrfx_gpiote/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_gpiote/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_nrfx_power/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_power/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_nrfx_prs/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_prs/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_nrfx_rng/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_rng/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_nrfx_rtc/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_rtc/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_nrfx_spi/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_spi/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_nrfx_spim/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_spim/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_nrfx_spis/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_spis/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_nrfx_systick/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_systick/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_nrfx_twi/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_twi/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_nrfx_twim/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_twim/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_nrfx_uart/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_uart/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_nrfx_uarte/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_uarte/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_nrfx_usbd/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_usbd/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_pwr_mgmt/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_pwr_mgmt/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atomic
   nrf5_balloc

--- a/ci/libraries_tests/nrf5_sdh/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_sdh/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_config
   nrf5_log_fwd

--- a/ci/libraries_tests/nrf5_sortlist/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_sortlist/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_spi_mngr/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_spi_mngr/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_stack_guard/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_stack_guard/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_twi_mngr/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_twi_mngr/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/patches/15.3.0/examples/ble_peripheral/ble_app_gatts_c/app_bsp.c.diff
+++ b/ci/patches/15.3.0/examples/ble_peripheral/ble_app_gatts_c/app_bsp.c.diff
@@ -1,0 +1,10 @@
+--- ci/sdks/15.3.0/examples/ble_peripheral/ble_app_gatts_c/app_bsp.c	2019-02-14 17:25:00.000000000 +0100
++++ ci/sdks/15.3.0/examples/ble_peripheral/ble_app_gatts_c/app_bsp2.c	2020-06-25 09:24:39.000000000 +0200
+@@ -109,6 +109,7 @@
+     APP_ERROR_CHECK(err_code);
+ }
+ 
++uint16_t m_conn_handle;
+ 
+ /**@brief Function for handling events from the BSP module.
+  *

--- a/ci/patches/16.0.0/examples/ble_peripheral/ble_app_gatts_c/app_bsp.c.diff
+++ b/ci/patches/16.0.0/examples/ble_peripheral/ble_app_gatts_c/app_bsp.c.diff
@@ -1,0 +1,10 @@
+--- ci/sdks/16.0.0/examples/ble_peripheral/ble_app_gatts_c/app_bsp.c	2020-06-25 09:31:13.000000000 +0200
++++ ci/sdks/16.0.0/examples/ble_peripheral/ble_app_gatts_c/app_bsp2.c	2020-06-25 09:31:27.000000000 +0200
+@@ -109,6 +109,7 @@
+     APP_ERROR_CHECK(err_code);
+ }
+ 
++uint16_t m_conn_handle;
+ 
+ /**@brief Function for handling events from the BSP module.
+  *

--- a/cmake/nrf5_app.cmake
+++ b/cmake/nrf5_app.cmake
@@ -56,6 +56,7 @@ target_link_libraries(nrf5_app_error PUBLIC
 )
 list(APPEND NRF5_LIBRARY_NRF5_APP_ERROR_DEPENDENCIES
   nrf5_app_error
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -205,6 +206,7 @@ target_link_libraries(nrf5_app_uart PUBLIC
   nrf5_drv_uart
 )
 list(APPEND NRF5_LIBRARY_NRF5_APP_UART_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_uart
   nrf5_app_util_platform
   nrf5_atfifo
@@ -252,6 +254,7 @@ target_link_libraries(nrf5_app_uart_fifo PUBLIC
 )
 list(APPEND NRF5_LIBRARY_NRF5_APP_UART_FIFO_DEPENDENCIES
   nrf5_app_fifo
+  nrf5_app_scheduler
   nrf5_app_uart_fifo
   nrf5_app_util_platform
   nrf5_atfifo

--- a/cmake/nrf5_ble.cmake
+++ b/cmake/nrf5_ble.cmake
@@ -222,6 +222,7 @@ target_link_libraries(nrf5_ble_gatt PUBLIC
   nrf5_strerror
 )
 list(APPEND NRF5_LIBRARY_NRF5_BLE_GATT_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/cmake/nrf5_ble_pm.cmake
+++ b/cmake/nrf5_ble_pm.cmake
@@ -38,6 +38,7 @@ target_link_libraries(nrf5_ble_lesc PUBLIC
   nrf5_soc
 )
 list(APPEND NRF5_LIBRARY_NRF5_BLE_LESC_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/cmake/nrf5_ble_srv.cmake
+++ b/cmake/nrf5_ble_srv.cmake
@@ -612,3 +612,51 @@ list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_BAS_DEPENDENCIES
   nrf5_soc
   nrf5_strerror
 )
+
+# BLE Health Thermometer Service
+add_library(nrf5_ble_srv_hts OBJECT EXCLUDE_FROM_ALL
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_hts/ble_hts.c"
+)
+target_include_directories(nrf5_ble_srv_hts PUBLIC
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_hts"
+)
+target_link_libraries(nrf5_ble_srv_hts PUBLIC
+  nrf5_ble_common
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  
+  target_link_libraries(nrf5_ble_srv_hts PUBLIC
+    nrf5_ble_gq
+  )
+endif()
+list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_HTS_DEPENDENCIES
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_srv_hts
+  nrf5_config
+  nrf5_delay
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_HTS_DEPENDENCIES
+    nrf5_balloc
+    nrf5_balloc_fwd
+    nrf5_ble_gq
+    nrf5_cli_fwd
+    nrf5_ext_fprintf
+    nrf5_memobj
+    nrf5_memobj_fwd
+    nrf5_queue
+  )
+endif()

--- a/cmake/nrf5_ble_srv.cmake
+++ b/cmake/nrf5_ble_srv.cmake
@@ -469,3 +469,54 @@ if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
     nrf5_ble_gq
   )
 endif()
+
+# BLE Alert Notification Client (Central)
+add_library(nrf5_ble_srv_ans_c OBJECT EXCLUDE_FROM_ALL
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_ans_c/ble_ans_c.c"
+)
+target_include_directories(nrf5_ble_srv_ans_c PUBLIC
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_ans_c"
+)
+target_link_libraries(nrf5_ble_srv_ans_c PUBLIC
+  nrf5_ble_db_discovery
+)
+list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_ANS_C_DEPENDENCIES
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_balloc_fwd
+  nrf5_ble_common
+  nrf5_ble_db_discovery
+  nrf5_ble_srv_ans_c
+  nrf5_cli
+  nrf5_cli_fwd
+  nrf5_config
+  nrf5_delay
+  nrf5_ext_fprintf
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_log
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_memobj
+  nrf5_memobj_fwd
+  nrf5_mtx
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_pwr_mgmt
+  nrf5_queue
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_ANS_C_DEPENDENCIES
+    nrf5_ble_gq
+  )
+endif()

--- a/cmake/nrf5_ble_srv.cmake
+++ b/cmake/nrf5_ble_srv.cmake
@@ -520,3 +520,95 @@ if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
     nrf5_ble_gq
   )
 endif()
+
+# BLE Running Speed and Cadence Service (Peripheral)
+add_library(nrf5_ble_srv_rscs OBJECT EXCLUDE_FROM_ALL
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_rscs/ble_rscs.c"
+)
+target_include_directories(nrf5_ble_srv_rscs PUBLIC
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_rscs"
+)
+target_link_libraries(nrf5_ble_srv_rscs PUBLIC
+  nrf5_ble_common
+)
+list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_RSCS_DEPENDENCIES
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_srv_rscs
+  nrf5_config
+  nrf5_delay
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+
+# BLE HID Service
+add_library(nrf5_ble_srv_hids OBJECT EXCLUDE_FROM_ALL
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_hids/ble_hids.c"
+)
+target_include_directories(nrf5_ble_srv_hids PUBLIC
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_hids"
+)
+target_link_libraries(nrf5_ble_srv_hids PUBLIC
+  nrf5_ble_common
+  nrf5_ble_link_ctx_manager
+)
+list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_HIDS_DEPENDENCIES
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_link_ctx_manager
+  nrf5_ble_srv_hids
+  nrf5_config
+  nrf5_delay
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+
+# BLE Battery Service (Peripheral)
+add_library(nrf5_ble_srv_bas OBJECT EXCLUDE_FROM_ALL
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_bas/ble_bas.c"
+)
+target_include_directories(nrf5_ble_srv_bas PUBLIC
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_bas"
+)
+target_link_libraries(nrf5_ble_srv_bas PUBLIC
+  nrf5_ble_common
+)
+list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_BAS_DEPENDENCIES
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_srv_bas
+  nrf5_config
+  nrf5_delay
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)

--- a/cmake/nrf5_ble_srv.cmake
+++ b/cmake/nrf5_ble_srv.cmake
@@ -660,3 +660,51 @@ if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
     nrf5_queue
   )
 endif()
+
+# BLE Blood Pressure Service (Peripheral)
+add_library(nrf5_ble_srv_bps OBJECT EXCLUDE_FROM_ALL
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_bps/ble_bps.c"
+)
+target_include_directories(nrf5_ble_srv_bps PUBLIC
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_bps"
+)
+target_link_libraries(nrf5_ble_srv_bps PUBLIC
+  nrf5_ble_common
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  
+  target_link_libraries(nrf5_ble_srv_bps PUBLIC
+    nrf5_ble_gq
+  )
+endif()
+list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_BPS_DEPENDENCIES
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_srv_bps
+  nrf5_config
+  nrf5_delay
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_BPS_DEPENDENCIES
+    nrf5_balloc
+    nrf5_balloc_fwd
+    nrf5_ble_gq
+    nrf5_cli_fwd
+    nrf5_ext_fprintf
+    nrf5_memobj
+    nrf5_memobj_fwd
+    nrf5_queue
+  )
+endif()

--- a/cmake/nrf5_ble_srv.cmake
+++ b/cmake/nrf5_ble_srv.cmake
@@ -739,3 +739,53 @@ list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_CSCS_DEPENDENCIES
   nrf5_soc
   nrf5_strerror
 )
+
+# BLE Location and Navigation Service
+add_library(nrf5_ble_srv_lns OBJECT EXCLUDE_FROM_ALL
+  "${NRF5_SDK_PATH}/components/ble/ble_services/experimental_ble_lns/ble_ln_cp.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/experimental_ble_lns/ble_ln_db.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/experimental_ble_lns/ble_lns.c"
+)
+target_include_directories(nrf5_ble_srv_lns PUBLIC
+  "${NRF5_SDK_PATH}/components/ble/ble_services/experimental_ble_lns"
+)
+target_link_libraries(nrf5_ble_srv_lns PUBLIC
+  nrf5_ble_common
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  
+  target_link_libraries(nrf5_ble_srv_lns PUBLIC
+    nrf5_ble_gq
+  )
+endif()
+list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_LNS_DEPENDENCIES
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_srv_lns
+  nrf5_config
+  nrf5_delay
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_LNS_DEPENDENCIES
+    nrf5_balloc
+    nrf5_balloc_fwd
+    nrf5_ble_gq
+    nrf5_cli_fwd
+    nrf5_ext_fprintf
+    nrf5_memobj
+    nrf5_memobj_fwd
+    nrf5_queue
+  )
+endif()

--- a/cmake/nrf5_ble_srv.cmake
+++ b/cmake/nrf5_ble_srv.cmake
@@ -418,3 +418,54 @@ if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
     nrf5_ble_gq
   )
 endif()
+
+# BLE Current Time Service Client (Central)
+add_library(nrf5_ble_srv_cts_c OBJECT EXCLUDE_FROM_ALL
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_cts_c/ble_cts_c.c"
+)
+target_include_directories(nrf5_ble_srv_cts_c PUBLIC
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_cts_c"
+)
+target_link_libraries(nrf5_ble_srv_cts_c PUBLIC
+  nrf5_ble_db_discovery
+)
+list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_CTS_C_DEPENDENCIES
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_balloc_fwd
+  nrf5_ble_common
+  nrf5_ble_db_discovery
+  nrf5_ble_srv_cts_c
+  nrf5_cli
+  nrf5_cli_fwd
+  nrf5_config
+  nrf5_delay
+  nrf5_ext_fprintf
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_log
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_memobj
+  nrf5_memobj_fwd
+  nrf5_mtx
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_pwr_mgmt
+  nrf5_queue
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_CTS_C_DEPENDENCIES
+    nrf5_ble_gq
+  )
+endif()

--- a/cmake/nrf5_ble_srv.cmake
+++ b/cmake/nrf5_ble_srv.cmake
@@ -708,3 +708,34 @@ if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
     nrf5_queue
   )
 endif()
+
+# BLE Cycling Speed and Cadence Service
+add_library(nrf5_ble_srv_cscs OBJECT EXCLUDE_FROM_ALL
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_cscs/ble_cscs.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_cscs/ble_sc_ctrlpt.c"
+)
+target_include_directories(nrf5_ble_srv_cscs PUBLIC
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_cscs"
+)
+target_link_libraries(nrf5_ble_srv_cscs PUBLIC
+  nrf5_ble_common
+)
+list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_CSCS_DEPENDENCIES
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_srv_cscs
+  nrf5_config
+  nrf5_delay
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)

--- a/cmake/nrf5_ble_srv.cmake
+++ b/cmake/nrf5_ble_srv.cmake
@@ -367,3 +367,54 @@ if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
     nrf5_ble_gq
   )
 endif()
+
+# BLE GATT Service Server (Central)
+add_library(nrf5_ble_srv_gatts_c OBJECT EXCLUDE_FROM_ALL
+  "${NRF5_SDK_PATH}/components/ble/ble_services/experimental_gatts_c/nrf_ble_gatts_c.c"
+)
+target_include_directories(nrf5_ble_srv_gatts_c PUBLIC
+  "${NRF5_SDK_PATH}/components/ble/ble_services/experimental_gatts_c"
+)
+target_link_libraries(nrf5_ble_srv_gatts_c PUBLIC
+  nrf5_ble_db_discovery
+)
+list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_GATTS_C_DEPENDENCIES
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_balloc_fwd
+  nrf5_ble_common
+  nrf5_ble_db_discovery
+  nrf5_ble_srv_gatts_c
+  nrf5_cli
+  nrf5_cli_fwd
+  nrf5_config
+  nrf5_delay
+  nrf5_ext_fprintf
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_log
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_memobj
+  nrf5_memobj_fwd
+  nrf5_mtx
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_pwr_mgmt
+  nrf5_queue
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_GATTS_C_DEPENDENCIES
+    nrf5_ble_gq
+  )
+endif()

--- a/cmake/nrf5_common.cmake
+++ b/cmake/nrf5_common.cmake
@@ -138,12 +138,14 @@ target_include_directories(nrf5_sdh PUBLIC
   "${NRF5_SDK_PATH}/components/softdevice/common"
 )
 target_link_libraries(nrf5_sdh PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_log_fwd
   nrf5_section
   nrf5_strerror
 )
 list(APPEND NRF5_LIBRARY_NRF5_SDH_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_config
   nrf5_log_fwd
@@ -341,6 +343,7 @@ target_link_libraries(nrf5_pwr_mgmt PUBLIC
   nrf5_section
 )
 list(APPEND NRF5_LIBRARY_NRF5_PWR_MGMT_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atomic
   nrf5_balloc
@@ -463,6 +466,7 @@ target_link_libraries(nrf5_sortlist PUBLIC
   nrf5_soc
 )
 list(APPEND NRF5_LIBRARY_NRF5_SORTLIST_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -526,6 +530,7 @@ target_link_libraries(nrf5_hardfault PUBLIC
   nrf5_soc
 )
 list(APPEND NRF5_LIBRARY_NRF5_HARDFAULT_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/cmake/nrf5_crypto.cmake
+++ b/cmake/nrf5_crypto.cmake
@@ -69,6 +69,7 @@ target_link_libraries(nrf5_crypto PUBLIC
   nrf5_stack_info
 )
 list(APPEND NRF5_LIBRARY_NRF5_CRYPTO_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -136,6 +137,7 @@ target_link_libraries(nrf5_crypto_cc310_backend PUBLIC
   nrf5_nrfx_common
 )
 list(APPEND NRF5_LIBRARY_NRF5_CRYPTO_CC310_BACKEND_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -194,6 +196,7 @@ target_link_libraries(nrf5_crypto_cc310_bl_backend PUBLIC
   nrf5_ext_cc310_bl_fwd
 )
 list(APPEND NRF5_LIBRARY_NRF5_CRYPTO_CC310_BL_BACKEND_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -251,6 +254,7 @@ target_link_libraries(nrf5_crypto_cifra_backend PUBLIC
   nrf5_soc
 )
 list(APPEND NRF5_LIBRARY_NRF5_CRYPTO_CIFRA_BACKEND_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -316,6 +320,7 @@ target_link_libraries(nrf5_crypto_mbedtls_backend PUBLIC
   nrf5_soc
 )
 list(APPEND NRF5_LIBRARY_NRF5_CRYPTO_MBEDTLS_BACKEND_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -376,6 +381,7 @@ target_link_libraries(nrf5_crypto_micro_ecc_backend PUBLIC
 )
 list(APPEND NRF5_LIBRARY_NRF5_CRYPTO_MICRO_ECC_BACKEND_DEPENDENCIES
   micro_ecc
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -438,6 +444,7 @@ target_link_libraries(nrf5_crypto_oberon_backend PUBLIC
   nrf5_soc
 )
 list(APPEND NRF5_LIBRARY_NRF5_CRYPTO_OBERON_BACKEND_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -497,6 +504,7 @@ target_link_libraries(nrf5_crypto_nrf_hw_backend PUBLIC
   nrf5_soc
 )
 list(APPEND NRF5_LIBRARY_NRF5_CRYPTO_NRF_HW_BACKEND_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -556,6 +564,7 @@ target_link_libraries(nrf5_crypto_nrf_sw_backend PUBLIC
   nrf5_soc
 )
 list(APPEND NRF5_LIBRARY_NRF5_CRYPTO_NRF_SW_BACKEND_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -623,6 +632,7 @@ if(NRF5_SDK_VERSION VERSION_EQUAL 15.3.0)
   )
 endif()
 list(APPEND NRF5_LIBRARY_NRF5_CRYPTO_OPTIGA_BACKEND_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/cmake/nrf5_external.cmake
+++ b/cmake/nrf5_external.cmake
@@ -181,6 +181,7 @@ if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
   )
 endif()
 list(APPEND NRF5_LIBRARY_NRF5_EXT_OPTIGA_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/cmake/nrf5_log.cmake
+++ b/cmake/nrf5_log.cmake
@@ -42,6 +42,7 @@ target_link_libraries(nrf5_cli PUBLIC
   nrf5_section
 )
 list(APPEND NRF5_LIBRARY_NRF5_CLI_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atomic
   nrf5_balloc
@@ -167,6 +168,7 @@ target_link_libraries(nrf5_cli_cdc_acm PUBLIC
   nrf5_cli
 )
 list(APPEND NRF5_LIBRARY_NRF5_CLI_CDC_ACM_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_usbd_cdc_acm
   nrf5_app_util_platform
@@ -231,6 +233,7 @@ target_link_libraries(nrf5_log PUBLIC
   nrf5_strerror
 )
 list(APPEND NRF5_LIBRARY_NRF5_LOG_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -268,6 +271,7 @@ target_link_libraries(nrf5_log_backend_serial PUBLIC
   nrf5_log
 )
 list(APPEND NRF5_LIBRARY_NRF5_LOG_BACKEND_SERIAL_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -307,6 +311,7 @@ target_link_libraries(nrf5_log_backend_uart PUBLIC
   nrf5_log
 )
 list(APPEND NRF5_LIBRARY_NRF5_LOG_BACKEND_UART_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -349,6 +354,7 @@ target_link_libraries(nrf5_log_backend_flash PUBLIC
   nrf5_log
 )
 list(APPEND NRF5_LIBRARY_NRF5_LOG_BACKEND_FLASH_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -388,6 +394,7 @@ target_link_libraries(nrf5_log_backend_rtt PUBLIC
   nrf5_log
 )
 list(APPEND NRF5_LIBRARY_NRF5_LOG_BACKEND_RTT_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -427,6 +434,7 @@ target_link_libraries(nrf5_log_default_backends PUBLIC
   nrf5_log
 )
 list(APPEND NRF5_LIBRARY_NRF5_LOG_DEFAULT_BACKENDS_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/cmake/nrf5_misc.cmake
+++ b/cmake/nrf5_misc.cmake
@@ -48,6 +48,7 @@ target_link_libraries(nrf5_gfx PUBLIC
   nrf5_nrfx_common
 )
 list(APPEND NRF5_LIBRARY_NRF5_GFX_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -92,6 +93,7 @@ target_link_libraries(nrf5_spi_mngr PUBLIC
   nrf5_queue
 )
 list(APPEND NRF5_LIBRARY_NRF5_SPI_MNGR_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -139,6 +141,7 @@ target_link_libraries(nrf5_twi_mngr PUBLIC
   nrf5_queue
 )
 list(APPEND NRF5_LIBRARY_NRF5_TWI_MNGR_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -183,6 +186,7 @@ target_link_libraries(nrf5_mpu PUBLIC
   nrf5_log
 )
 list(APPEND NRF5_LIBRARY_NRF5_MPU_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -225,6 +229,7 @@ target_link_libraries(nrf5_stack_guard PUBLIC
   nrf5_mpu
 )
 list(APPEND NRF5_LIBRARY_NRF5_STACK_GUARD_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/cmake/nrf5_nrfx.cmake
+++ b/cmake/nrf5_nrfx.cmake
@@ -83,6 +83,7 @@ target_link_libraries(nrf5_nrfx_prs PUBLIC
   nrf5_log
 )
 list(APPEND NRF5_LIBRARY_NRF5_NRFX_PRS_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -126,6 +127,7 @@ target_link_libraries(nrf5_nrfx_clock PUBLIC
   nrf5_nrfx_common
 )
 list(APPEND NRF5_LIBRARY_NRF5_NRFX_CLOCK_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -167,6 +169,7 @@ target_link_libraries(nrf5_drv_clock PUBLIC
   nrf5_nrfx_clock
 )
 list(APPEND NRF5_LIBRARY_NRF5_DRV_CLOCK_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -211,6 +214,7 @@ target_link_libraries(nrf5_nrfx_systick PUBLIC
   nrf5_nrfx_common
 )
 list(APPEND NRF5_LIBRARY_NRF5_NRFX_SYSTICK_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -250,6 +254,7 @@ target_link_libraries(nrf5_drv_systick INTERFACE
   nrf5_nrfx_systick
 )
 list(APPEND NRF5_LIBRARY_NRF5_DRV_SYSTICK_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -294,6 +299,7 @@ target_link_libraries(nrf5_nrfx_power PUBLIC
   nrf5_nrfx_common
 )
 list(APPEND NRF5_LIBRARY_NRF5_NRFX_POWER_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -335,6 +341,7 @@ target_link_libraries(nrf5_drv_power PUBLIC
   nrf5_nrfx_power
 )
 list(APPEND NRF5_LIBRARY_NRF5_DRV_POWER_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -380,6 +387,7 @@ target_link_libraries(nrf5_nrfx_gpiote PUBLIC
   nrf5_nrfx_common
 )
 list(APPEND NRF5_LIBRARY_NRF5_NRFX_GPIOTE_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -422,6 +430,7 @@ target_link_libraries(nrf5_nrfx_uarte PUBLIC
   nrf5_nrfx_common
 )
 list(APPEND NRF5_LIBRARY_NRF5_NRFX_UARTE_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -464,6 +473,7 @@ target_link_libraries(nrf5_nrfx_uart PUBLIC
   nrf5_nrfx_common
 )
 list(APPEND NRF5_LIBRARY_NRF5_NRFX_UART_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -506,6 +516,7 @@ target_link_libraries(nrf5_drv_uart PUBLIC
   nrf5_nrfx_uarte
 )
 list(APPEND NRF5_LIBRARY_NRF5_DRV_UART_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -550,6 +561,7 @@ target_link_libraries(nrf5_nrfx_rng PUBLIC
   nrf5_nrfx_common
 )
 list(APPEND NRF5_LIBRARY_NRF5_NRFX_RNG_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -593,6 +605,7 @@ target_link_libraries(nrf5_drv_rng PUBLIC
   nrf5_soc
 )
 list(APPEND NRF5_LIBRARY_NRF5_DRV_RNG_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -635,6 +648,7 @@ target_link_libraries(nrf5_drv_twi PUBLIC
   nrf5_nrfx_twi
 )
 list(APPEND NRF5_LIBRARY_NRF5_DRV_TWI_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -681,6 +695,7 @@ target_link_libraries(nrf5_nrfx_twi PUBLIC
   nrf5_soc
 )
 list(APPEND NRF5_LIBRARY_NRF5_NRFX_TWI_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -724,6 +739,7 @@ target_link_libraries(nrf5_nrfx_twim PUBLIC
   nrf5_nrfx_common
 )
 list(APPEND NRF5_LIBRARY_NRF5_NRFX_TWIM_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -778,6 +794,7 @@ target_link_libraries(nrf5_nrfx_rtc PUBLIC
   nrf5_soc
 )
 list(APPEND NRF5_LIBRARY_NRF5_NRFX_RTC_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -842,6 +859,7 @@ target_link_libraries(nrf5_nrfx_spi PUBLIC
   nrf5_nrfx_common
 )
 list(APPEND NRF5_LIBRARY_NRF5_NRFX_SPI_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -885,6 +903,7 @@ target_link_libraries(nrf5_nrfx_spim PUBLIC
   nrf5_nrfx_common
 )
 list(APPEND NRF5_LIBRARY_NRF5_NRFX_SPIM_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -928,6 +947,7 @@ target_link_libraries(nrf5_nrfx_spis PUBLIC
   nrf5_nrfx_common
 )
 list(APPEND NRF5_LIBRARY_NRF5_NRFX_SPIS_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -970,6 +990,7 @@ target_link_libraries(nrf5_drv_spi PUBLIC
   nrf5_nrfx_spim
 )
 list(APPEND NRF5_LIBRARY_NRF5_DRV_SPI_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -1013,6 +1034,7 @@ target_link_libraries(nrf5_drv_spis PUBLIC
   nrf5_nrfx_spis
 )
 list(APPEND NRF5_LIBRARY_NRF5_DRV_SPIS_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -1059,6 +1081,7 @@ target_link_libraries(nrf5_nrfx_usbd PUBLIC
   nrf5_nrfx_systick
 )
 list(APPEND NRF5_LIBRARY_NRF5_NRFX_USBD_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -1100,6 +1123,7 @@ target_link_libraries(nrf5_drv_usbd INTERFACE
   nrf5_nrfx_usbd
 )
 list(APPEND NRF5_LIBRARY_NRF5_DRV_USBD_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/cmake/nrf5_storage.cmake
+++ b/cmake/nrf5_storage.cmake
@@ -60,6 +60,7 @@ target_link_libraries(nrf5_fstorage_sd PUBLIC
   nrf5_section
 )
 list(APPEND NRF5_LIBRARY_NRF5_FSTORAGE_SD_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/cmake/nrf5_usbd.cmake
+++ b/cmake/nrf5_usbd.cmake
@@ -38,6 +38,7 @@ target_link_libraries(nrf5_app_usbd PUBLIC
   nrf5_ext_utf_converter
 )
 list(APPEND NRF5_LIBRARY_NRF5_APP_USBD_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_util_platform
   nrf5_atfifo
@@ -85,6 +86,7 @@ target_link_libraries(nrf5_app_usbd_serial_num PUBLIC
   nrf5_app_usbd
 )
 list(APPEND NRF5_LIBRARY_NRF5_APP_USBD_SERIAL_NUM_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_usbd_serial_num
   nrf5_app_util_platform
@@ -137,6 +139,7 @@ target_link_libraries(nrf5_app_usbd_cdc_acm PUBLIC
   nrf5_app_usbd
 )
 list(APPEND NRF5_LIBRARY_NRF5_APP_USBD_CDC_ACM_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_usbd_cdc_acm
   nrf5_app_util_platform
@@ -188,6 +191,7 @@ target_link_libraries(nrf5_app_usbd_hid PUBLIC
   nrf5_app_usbd
 )
 list(APPEND NRF5_LIBRARY_NRF5_APP_USBD_HID_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_usbd_hid
   nrf5_app_util_platform
@@ -239,6 +243,7 @@ target_link_libraries(nrf5_app_usbd_hid_generic PUBLIC
   nrf5_app_usbd_hid
 )
 list(APPEND NRF5_LIBRARY_NRF5_APP_USBD_HID_GENERIC_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_usbd_hid
   nrf5_app_usbd_hid_generic
@@ -291,6 +296,7 @@ target_link_libraries(nrf5_app_usbd_hid_kbd PUBLIC
   nrf5_app_usbd_hid
 )
 list(APPEND NRF5_LIBRARY_NRF5_APP_USBD_HID_KBD_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_usbd_hid
   nrf5_app_usbd_hid_kbd
@@ -343,6 +349,7 @@ target_link_libraries(nrf5_app_usbd_hid_mouse PUBLIC
   nrf5_app_usbd_hid
 )
 list(APPEND NRF5_LIBRARY_NRF5_APP_USBD_HID_MOUSE_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_usbd_hid
   nrf5_app_usbd_hid_mouse
@@ -396,6 +403,7 @@ target_link_libraries(nrf5_app_usbd_msc PUBLIC
   nrf5_block_dev
 )
 list(APPEND NRF5_LIBRARY_NRF5_APP_USBD_MSC_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_usbd_msc
   nrf5_app_util_platform
@@ -448,6 +456,7 @@ target_link_libraries(nrf5_app_usbd_audio PUBLIC
   nrf5_app_usbd
 )
 list(APPEND NRF5_LIBRARY_NRF5_APP_USBD_AUDIO_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_usbd_audio
   nrf5_app_util_platform
@@ -500,6 +509,7 @@ target_link_libraries(nrf5_app_usbd_dummy PUBLIC
   nrf5_block_dev
 )
 list(APPEND NRF5_LIBRARY_NRF5_APP_USBD_DUMMY_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_usbd_dummy
   nrf5_app_util_platform
@@ -553,6 +563,7 @@ target_link_libraries(nrf5_app_usbd_nrf_dfu_trigger PUBLIC
   nrf5_block_dev
 )
 list(APPEND NRF5_LIBRARY_NRF5_APP_USBD_NRF_DFU_TRIGGER_DEPENDENCIES
+  nrf5_app_scheduler
   nrf5_app_usbd
   nrf5_app_usbd_nrf_dfu_trigger
   nrf5_app_util_platform


### PR DESCRIPTION
New examples:
* ble_app_gatts_c 
* ble_app_cts_c 
* ble_app_alert_notification
* ble_app_rscs
* ble_app_hids_mouse
* ble_app_hids_keyboard
* ble_app_hts
* ble_app_bps
* ble_app_cscs
* ble_app_lns

New libraries:
* nrf5_ble_srv_gatts_c
* nrf5_ble_srv_cts_c
* nrf5_ble_srv_ans_c
* nrf5_ble_srv_bas_c
* nrf5_ble_srv_hids_c
* nrf5_ble_srv_rscs_c
* nrf5_ble_srv_hts
* nrf5_ble_srv_bps
* nrf5_ble_srv_cscs
* nrf5_ble_srv_lns

Other:
* add nrf5_app_scheduler dependency to nrf5_sdh
