### PR TITLE
Add more ble_peripheral examples and libraries.

### DIFF
--- a/ci/examples/ble_peripheral/ble_app_ancs_c/CMakeLists.txt
+++ b/ci/examples/ble_peripheral/ble_app_ancs_c/CMakeLists.txt
@@ -1,0 +1,107 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.14)
+project(ble_app_ancs_c LANGUAGES C ASM)
+
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME}
+  "${NRF5_SDK_PATH}/examples/ble_peripheral/ble_app_ancs_c/main.c"
+)
+
+target_compile_definitions(nrf5_config INTERFACE
+  # APP_TIMER_V2
+  # APP_TIMER_V2_RTC1_ENABLED
+  CONFIG_GPIO_AS_PINRESET
+  NRFX_COREDEP_DELAY_US_LOOP_CYCLES=3
+)    
+
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+  nrf5_app_button
+  nrf5_app_error
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_assert
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_ble_advertising
+  nrf5_ble_auth_status_tracker
+  nrf5_ble_common
+  nrf5_ble_db_discovery
+  nrf5_ble_gatt
+  nrf5_ble_gatt_cache_manager
+  nrf5_ble_id_manager
+  nrf5_ble_peer_data_storage
+  nrf5_ble_peer_database
+  nrf5_ble_peer_id
+  nrf5_ble_peer_manager
+  nrf5_ble_peer_manager_handler
+  nrf5_ble_pm_buffer
+  nrf5_ble_qwr
+  nrf5_ble_security_dispatcher
+  nrf5_ble_security_manager
+  nrf5_ble_srv_gatts_c
+  nrf5_ble_srv_ancs_c
+  nrf5_boards
+  nrf5_bsp
+  nrf5_bsp_btn_ble
+  nrf5_crc16
+  nrf5_drv_clock
+  nrf5_drv_uart
+  nrf5_ext_fprintf
+  nrf5_ext_segger_rtt
+  nrf5_ext_utf_converter
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_fstorage_sd
+  nrf5_hardfault
+  nrf5_log
+  nrf5_log_backend_rtt
+  nrf5_log_backend_serial
+  nrf5_log_backend_uart
+  nrf5_log_default_backends
+  nrf5_mdk
+  nrf5_memobj
+  nrf5_nrfx_clock
+  nrf5_nrfx_gpiote
+  nrf5_nrfx_prs
+  nrf5_nrfx_soc
+  nrf5_nrfx_uart
+  nrf5_nrfx_uarte
+  nrf5_pwr_mgmt
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_sortlist
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+    nrf5_ble_gq
+    nrf5_queue
+  )
+endif()

--- a/ci/examples/ble_peripheral/ble_app_eddystone/CMakeLists.txt
+++ b/ci/examples/ble_peripheral/ble_app_eddystone/CMakeLists.txt
@@ -1,0 +1,117 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.14)
+project(ble_app_eddystone LANGUAGES C ASM)
+
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME}
+  "${NRF5_SDK_PATH}/examples/ble_peripheral/ble_app_eddystone/main.c"
+)
+
+# Patch eddystone lib
+target_include_directories(nrf5_ble_srv_eddystone PRIVATE
+  "${NRF5_SDK_PATH}/examples/ble_peripheral/ble_app_eddystone"
+)
+target_link_libraries(nrf5_ble_srv_eddystone PRIVATE
+  nrf5_boards
+)
+
+# Example global definitions
+add_compile_definitions(
+  NRFX_COREDEP_DELAY_US_LOOP_CYCLES=3
+  NRF_CRYPTO_MAX_INSTANCE_COUNT=1
+  uECC_ENABLE_VLI_API=0
+  uECC_SQUARE_FUNC=0
+  uECC_SUPPORT_COMPRESSED_POINT=0
+  uECC_VLI_NATIVE_LITTLE_ENDIAN=1
+)
+
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+  nrf5_app_button
+  nrf5_app_error
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_assert
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_ble_advertising
+  nrf5_ble_common
+  nrf5_ble_gatt
+  nrf5_ble_srv_eddystone
+  nrf5_boards
+  nrf5_bsp
+  nrf5_bsp_btn_ble
+  nrf5_crc16
+  nrf5_crypto
+  nrf5_crypto_cc310_backend
+  nrf5_crypto_cifra_backend
+  nrf5_crypto_mbedtls_backend
+  nrf5_crypto_micro_ecc_backend
+  nrf5_crypto_nrf_hw_backend
+  nrf5_crypto_oberon_backend
+  nrf5_drv_clock
+  nrf5_drv_rng
+  nrf5_drv_uart
+  nrf5_ext_cifra_aes128_eax
+  nrf5_ext_fprintf
+  nrf5_ext_mbedcrypto
+  nrf5_ext_mbedtls
+  nrf5_ext_mbedx509
+  nrf5_ext_segger_rtt
+  nrf5_ext_utf_converter
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_fstorage_nvmc
+  nrf5_fstorage_sd
+  nrf5_hardfault
+  nrf5_log
+  nrf5_log_backend_rtt
+  nrf5_log_backend_serial
+  nrf5_log_backend_uart
+  nrf5_log_default_backends
+  nrf5_mdk
+  nrf5_mem_manager
+  nrf5_memobj
+  nrf5_nrfx_clock
+  nrf5_nrfx_gpiote
+  nrf5_nrfx_nvmc
+  nrf5_nrfx_prs
+  nrf5_nrfx_rng
+  nrf5_nrfx_saadc
+  nrf5_nrfx_soc
+  nrf5_nrfx_uart
+  nrf5_nrfx_uarte
+  nrf5_pwr_mgmt
+  nrf5_queue
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_sensorsim
+  nrf5_sortlist
+  nrf5_strerror
+)

--- a/ci/examples/ble_peripheral/ble_app_gls/CMakeLists.txt
+++ b/ci/examples/ble_peripheral/ble_app_gls/CMakeLists.txt
@@ -1,0 +1,119 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.14)
+project(ble_app_gls LANGUAGES C ASM)
+
+include("nrf5")
+
+set(CMAKE_BUILD_TYPE MinSizeRel CACHE STRING "" FORCE)
+
+add_executable(${CMAKE_PROJECT_NAME}
+  "${NRF5_SDK_PATH}/examples/ble_peripheral/ble_app_gls/main.c"
+)
+target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE
+  NRFX_COREDEP_DELAY_US_LOOP_CYCLES=3
+  NRF_APP_VERSION=0x00000001
+  NRF_APP_VERSION_ADDR=0x1D000
+  NRF_CRYPTO_MAX_INSTANCE_COUNT=1
+)    
+
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+  nrf5_app_button
+  nrf5_app_error
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_assert
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_ble_advertising
+  nrf5_ble_auth_status_tracker
+  nrf5_ble_common
+  nrf5_ble_gatt
+  nrf5_ble_gatt_cache_manager
+  nrf5_ble_id_manager
+  nrf5_ble_lesc
+  nrf5_ble_peer_data_storage
+  nrf5_ble_peer_database
+  nrf5_ble_peer_id
+  nrf5_ble_peer_manager
+  nrf5_ble_peer_manager_handler
+  nrf5_ble_pm_buffer
+  nrf5_ble_racp
+  nrf5_ble_qwr
+  nrf5_ble_security_dispatcher
+  nrf5_ble_security_manager
+  nrf5_ble_srv_bas
+  nrf5_ble_srv_dis
+  nrf5_ble_srv_gls
+  nrf5_boards
+  nrf5_bsp
+  nrf5_bsp_btn_ble
+  nrf5_crc16
+  nrf5_crypto
+  nrf5_crypto_cc310_backend
+  nrf5_crypto_nrf_hw_backend
+  nrf5_crypto_oberon_backend
+  nrf5_drv_clock
+  nrf5_drv_rng
+  nrf5_drv_uart
+  nrf5_ext_fprintf
+  nrf5_ext_mbedcrypto
+  nrf5_ext_segger_rtt
+  nrf5_ext_utf_converter
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_fstorage_sd
+  nrf5_hardfault
+  nrf5_log
+  nrf5_log_backend_rtt
+  nrf5_log_backend_serial
+  nrf5_log_backend_uart
+  nrf5_log_default_backends
+  nrf5_mdk
+  nrf5_mem_manager
+  nrf5_memobj
+  nrf5_nrfx_clock
+  nrf5_nrfx_gpiote
+  nrf5_nrfx_prs
+  nrf5_nrfx_rng
+  nrf5_nrfx_soc
+  nrf5_nrfx_uart
+  nrf5_nrfx_uarte
+  nrf5_pwr_mgmt
+  nrf5_queue
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_sensorsim
+  nrf5_sortlist
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+    nrf5_ble_gq
+  )
+endif()

--- a/ci/examples/ble_peripheral/ble_app_proximity/CMakeLists.txt
+++ b/ci/examples/ble_peripheral/ble_app_proximity/CMakeLists.txt
@@ -1,0 +1,110 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.14)
+project(ble_app_proximity LANGUAGES C ASM)
+
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME}
+  "${NRF5_SDK_PATH}/examples/ble_peripheral/ble_app_proximity/main.c"
+)
+target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE
+  CONFIG_GPIO_AS_PINRESET
+  NRFX_COREDEP_DELAY_US_LOOP_CYCLES=3
+)
+
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+  nrf5_app_button
+  nrf5_app_error
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_assert
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_ble_advertising
+  nrf5_ble_auth_status_tracker
+  nrf5_ble_common
+  nrf5_ble_db_discovery
+  nrf5_ble_gatt
+  nrf5_ble_gatt_cache_manager
+  nrf5_ble_id_manager
+  nrf5_ble_link_ctx_manager
+  nrf5_ble_peer_data_storage
+  nrf5_ble_peer_database
+  nrf5_ble_peer_id
+  nrf5_ble_peer_manager
+  nrf5_ble_peer_manager_handler
+  nrf5_ble_pm_buffer
+  nrf5_ble_qwr
+  nrf5_ble_security_dispatcher
+  nrf5_ble_security_manager
+  nrf5_ble_srv_bas
+  nrf5_ble_srv_ias
+  nrf5_ble_srv_ias_c
+  nrf5_ble_srv_lls
+  nrf5_ble_srv_tps
+  nrf5_boards
+  nrf5_bsp
+  nrf5_bsp_btn_ble
+  nrf5_crc16
+  nrf5_drv_clock
+  nrf5_drv_uart
+  nrf5_ext_fprintf
+  nrf5_ext_segger_rtt
+  nrf5_ext_utf_converter
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_fstorage_sd
+  nrf5_hardfault
+  nrf5_log
+  nrf5_log_backend_rtt
+  nrf5_log_backend_serial
+  nrf5_log_backend_uart
+  nrf5_log_default_backends
+  nrf5_mdk
+  nrf5_memobj
+  nrf5_nrfx_clock
+  nrf5_nrfx_gpiote
+  nrf5_nrfx_prs
+  nrf5_nrfx_saadc
+  nrf5_nrfx_soc
+  nrf5_nrfx_uart
+  nrf5_nrfx_uarte
+  nrf5_pwr_mgmt
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_sensorsim
+  nrf5_sortlist
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+    nrf5_ble_gq
+    nrf5_queue
+  )
+endif()

--- a/ci/examples/ble_peripheral/experimental/ble_app_cgms/CMakeLists.txt
+++ b/ci/examples/ble_peripheral/experimental/ble_app_cgms/CMakeLists.txt
@@ -1,0 +1,103 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.14)
+project(ble_app_cgms LANGUAGES C ASM)
+
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME}
+  "${NRF5_SDK_PATH}/examples/ble_peripheral/experimental/ble_app_cgms/main.c"
+)
+
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+  nrf5_app_button
+  nrf5_app_error
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_assert
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_ble_advertising
+  nrf5_ble_auth_status_tracker
+  nrf5_ble_common
+  nrf5_ble_gatt
+  nrf5_ble_gatt_cache_manager
+  nrf5_ble_id_manager
+  nrf5_ble_peer_data_storage
+  nrf5_ble_peer_database
+  nrf5_ble_peer_id
+  nrf5_ble_peer_manager
+  nrf5_ble_peer_manager_handler
+  nrf5_ble_pm_buffer
+  nrf5_ble_qwr
+  nrf5_ble_racp
+  nrf5_ble_security_dispatcher
+  nrf5_ble_security_manager
+  nrf5_ble_srv_bas
+  nrf5_ble_srv_bms
+  nrf5_ble_srv_dis
+  nrf5_ble_srv_cgms
+  nrf5_boards
+  nrf5_bsp
+  nrf5_bsp_btn_ble
+  nrf5_crc16
+  nrf5_drv_clock
+  nrf5_drv_uart
+  nrf5_ext_fprintf
+  nrf5_ext_segger_rtt
+  nrf5_ext_utf_converter
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_fstorage_sd
+  nrf5_hardfault
+  nrf5_log
+  nrf5_log_backend_rtt
+  nrf5_log_backend_serial
+  nrf5_log_backend_uart
+  nrf5_log_default_backends
+  nrf5_mdk
+  nrf5_memobj
+  nrf5_nrfx_clock
+  nrf5_nrfx_gpiote
+  nrf5_nrfx_prs
+  nrf5_nrfx_soc
+  nrf5_nrfx_uart
+  nrf5_nrfx_uarte
+  nrf5_pwr_mgmt
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_sensorsim
+  nrf5_sortlist
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+    nrf5_ble_gq
+    nrf5_queue
+  )
+endif()

--- a/ci/examples/ble_peripheral/experimental/ble_app_ots/CMakeLists.txt
+++ b/ci/examples/ble_peripheral/experimental/ble_app_ots/CMakeLists.txt
@@ -1,0 +1,88 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.14)
+project(ble_app_ots LANGUAGES C ASM)
+
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME}
+  "${NRF5_SDK_PATH}/examples/ble_peripheral/experimental/ble_app_ots/main.c"
+)
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+  nrf5_app_button
+  nrf5_app_error
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_assert
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_ble_advertising
+  nrf5_ble_common
+  nrf5_ble_qwr
+  nrf5_ble_srv_ots
+  nrf5_boards
+  nrf5_bsp
+  nrf5_bsp_btn_ble
+  nrf5_crc16
+  nrf5_crc32
+  nrf5_drv_clock
+  nrf5_drv_uart
+  nrf5_ext_fprintf
+  nrf5_ext_segger_rtt
+  nrf5_ext_utf_converter
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_fstorage_nvmc
+  nrf5_fstorage_sd
+  nrf5_hardfault
+  nrf5_log
+  nrf5_log_backend_rtt
+  nrf5_log_backend_serial
+  nrf5_log_backend_uart
+  nrf5_log_default_backends
+  nrf5_mdk
+  nrf5_memobj
+  nrf5_nrfx_clock
+  nrf5_nrfx_gpiote
+  nrf5_nrfx_nvmc
+  nrf5_nrfx_prs
+  nrf5_nrfx_soc
+  nrf5_nrfx_uart
+  nrf5_nrfx_uarte
+  nrf5_pwr_mgmt
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_sortlist
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
+    nrf5_ble_gq
+    nrf5_queue
+  )
+endif()

--- a/ci/libraries/nrf5_app.json
+++ b/ci/libraries/nrf5_app.json
@@ -203,7 +203,8 @@
     "dependencies": {
       "public": [
         "nrf5_drv_spi",
-        "nrf5_ext_protothreads"
+        "nrf5_ext_protothreads",
+        "nrf5_nrfx_prs"
       ]
     },
     "includes": {

--- a/ci/libraries/nrf5_ble.json
+++ b/ci/libraries/nrf5_ble.json
@@ -170,5 +170,25 @@
         "components/ble/nrf_ble_gq"
       ]
     }
+  },
+  "nrf5_ble_racp": {
+    "documentation": "BLE Record Access Control Point library",
+    "variant": "object",
+    "sources": [
+      "components/ble/ble_racp/ble_racp.c"
+    ],
+    "dependencies": {
+      "public": [
+        "nrf5_config",
+        "nrf5_mdk",
+        "nrf5_soc"
+      ]
+    },
+    "includes": {
+      "public": [
+        "components/libraries/util",
+        "components/ble/ble_racp"
+      ]
+    }
   }
 }

--- a/ci/libraries/nrf5_ble_srv.json
+++ b/ci/libraries/nrf5_ble_srv.json
@@ -146,6 +146,24 @@
       ]
     }
   },
+  "nrf5_ble_srv_ias": {
+    "documentation": "BLE Immediate Alert Service Client (Peripheral)",
+    "variant": "object",
+    "sources": [
+      "components/ble/ble_services/ble_ias/ble_ias.c"
+    ],
+    "dependencies": {
+      "public": [
+        "nrf5_ble_common",
+        "nrf5_ble_link_ctx_manager"
+      ]
+    },
+    "includes": {
+      "public": [
+        "components/ble/ble_services/ble_ias"
+      ]
+    }
+  },
   "nrf5_ble_srv_ias_c": {
     "documentation": "BLE Immediate Alert Service Client (Central)",
     "variant": "object",
@@ -391,6 +409,219 @@
     "includes": {
       "public": [
         "components/ble/ble_services/ble_hrs"
+      ]
+    }
+  },
+  "nrf5_ble_srv_tps": {
+    "documentation": "BLE TX Power Service",
+    "variant": "object",
+    "sources": [
+      "components/ble/ble_services/ble_tps/ble_tps.c"
+    ],
+    "dependencies": {
+      "public": [
+        "nrf5_ble_common"
+      ]
+    },
+    "includes": {
+      "public": [
+        "components/ble/ble_services/ble_tps"
+      ]
+    }
+  },
+  "nrf5_ble_srv_gls": {
+    "documentation": "BLE Glucose Service",
+    "variant": "object",
+    "sources": [
+      "components/ble/ble_services/ble_gls/ble_gls.c",
+      "components/ble/ble_services/ble_gls/ble_gls_db.c"
+    ],
+    "dependencies": {
+      "public": [
+        "nrf5_ble_common",
+        "nrf5_ble_racp"
+      ]
+    },
+    "includes": {
+      "public": [
+        "components/ble/ble_services/ble_gls"
+      ]
+    },
+    "patches": [
+      {
+        "operation": "add",
+        "sdk_version": {
+          "from": "16.0.0"
+        },
+        "dependencies": {
+          "public": [
+            "nrf5_ble_gq"
+          ]
+        }
+      }
+    ]
+  },
+  "nrf5_ble_srv_ancs_c": {
+    "documentation": "BLE Apple Notification Center Service",
+    "variant": "object",
+    "sources": [
+      "components/ble/ble_services/ble_ancs_c/ancs_app_attr_get.c",
+      "components/ble/ble_services/ble_ancs_c/ancs_attr_parser.c",
+      "components/ble/ble_services/ble_ancs_c/ancs_tx_buffer.c",
+      "components/ble/ble_services/ble_ancs_c/nrf_ble_ancs_c.c"
+    ],
+    "dependencies": {
+      "public": [
+        "nrf5_ble_db_discovery"
+      ]
+    },
+    "includes": {
+      "public": [
+        "components/ble/ble_services/ble_ancs_c"
+      ]
+    },
+    "patches": [
+      {
+        "operation": "remove",
+        "sdk_version": {
+          "from": "16.0.0"
+        },
+        "sources": [
+          "components/ble/ble_services/ble_ancs_c/ancs_tx_buffer.c"
+        ]
+      },
+      {
+        "operation": "add",
+        "sdk_version": {
+          "from": "16.0.0"
+        },
+        "dependencies": {
+          "public": [
+            "nrf5_ble_gq"
+          ]
+        }
+      }
+    ] 
+  },
+  "nrf5_ble_srv_ots": {
+    "documentation": "BLE Object Transfer Service",
+    "variant": "object",
+    "sources": [
+      "components/ble/ble_services/experimental_ble_ots/ble_ots.c",
+      "components/ble/ble_services/experimental_ble_ots/ble_ots_l2cap.c",
+      "components/ble/ble_services/experimental_ble_ots/ble_ots_oacp.c",
+      "components/ble/ble_services/experimental_ble_ots/ble_ots_object.c",
+      "components/ble/ble_services/experimental_ble_ots/ble_hvx_buffering.c"
+    ],
+    "dependencies": {
+      "public": [
+        "nrf5_ble_common",
+        "nrf5_fds",
+        "nrf5_crc32"
+      ]
+    },
+    "includes": {
+      "public": [
+        "components/ble/ble_services/experimental_ble_ots"
+      ]
+    },
+    "patches": [
+      {
+        "operation": "remove",
+        "sdk_version": {
+          "from": "16.0.0"
+        },
+        "sources": [
+          "components/ble/ble_services/experimental_ble_ots/ble_hvx_buffering.c"
+        ]
+      },
+      {
+        "operation": "add",
+        "sdk_version": {
+          "from": "16.0.0"
+        },
+        "dependencies": {
+          "public": [
+            "nrf5_ble_gq"
+          ]
+        }
+      }
+    ]
+  },
+  "nrf5_ble_srv_cgms": {
+    "documentation": "BLE Continuous Glucose Monitoring Service",
+    "variant": "object",
+    "sources": [
+      "components/ble/ble_services/experimental_nrf_ble_cgms/cgms_db.c",
+      "components/ble/ble_services/experimental_nrf_ble_cgms/cgms_meas.c",
+      "components/ble/ble_services/experimental_nrf_ble_cgms/cgms_racp.c",
+      "components/ble/ble_services/experimental_nrf_ble_cgms/cgms_socp.c",
+      "components/ble/ble_services/experimental_nrf_ble_cgms/cgms_sst.c",
+      "components/ble/ble_services/experimental_nrf_ble_cgms/nrf_ble_cgms.c"
+    ],
+    "dependencies": {
+      "public": [
+        "nrf5_ble_common",
+        "nrf5_ble_racp"
+      ]
+    },
+    "includes": {
+      "public": [
+        "components/ble/ble_services/experimental_nrf_ble_cgms"
+      ]
+    },
+    "patches": [
+      {
+        "operation": "add",
+        "sdk_version": {
+          "from": "16.0.0"
+        },
+        "dependencies": {
+          "public": [
+            "nrf5_ble_gq"
+          ]
+        }
+      }
+    ]
+  },
+  "nrf5_ble_srv_eddystone": {
+    "documentation": "BLE Eddystone library",
+    "variant": "object",
+    "sources": [
+      "components/ble/ble_services/ble_escs/nrf_ble_escs.c",
+      "components/ble/ble_services/eddystone/es_adv.c",
+      "components/ble/ble_services/eddystone/es_adv_frame.c",
+      "components/ble/ble_services/eddystone/es_adv_timing.c",
+      "components/ble/ble_services/eddystone/es_adv_timing_resolver.c",
+      "components/ble/ble_services/eddystone/es_battery_voltage_saadc.c",
+      "components/ble/ble_services/eddystone/es_flash.c",
+      "components/ble/ble_services/eddystone/es_gatts.c",
+      "components/ble/ble_services/eddystone/es_gatts_read.c",
+      "components/ble/ble_services/eddystone/es_gatts_write.c",
+      "components/ble/ble_services/eddystone/es_security.c",
+      "components/ble/ble_services/eddystone/es_slot.c",
+      "components/ble/ble_services/eddystone/es_slot_reg.c",
+      "components/ble/ble_services/eddystone/es_stopwatch.c",
+      "components/ble/ble_services/eddystone/es_tlm.c",
+      "components/ble/ble_services/eddystone/nrf_ble_es.c"
+    ],
+    "dependencies": {
+      "public": [
+        "nrf5_app_scheduler",
+        "nrf5_ble_common",
+        "nrf5_drv_saadc",
+        "nrf5_fds",
+        "nrf5_crypto",
+        "nrf5_crypto_cifra_backend",
+        "nrf5_crypto_mbedtls_backend",
+        "nrf5_crypto_nrf_hw_backend",
+        "nrf5_crypto_oberon_backend"
+      ]
+    },
+    "includes": {
+      "public": [
+        "components/ble/ble_services/eddystone",
+        "components/ble/ble_services/ble_escs"
       ]
     }
   }

--- a/ci/libraries/nrf5_nrfx.json
+++ b/ci/libraries/nrf5_nrfx.json
@@ -250,7 +250,8 @@
     "dependencies": {
       "public": [
         "nrf5_log",
-        "nrf5_nrfx_common"
+        "nrf5_nrfx_common",
+        "nrf5_nrfx_prs"
       ]
     },
     "includes": {
@@ -268,7 +269,8 @@
     "dependencies": {
       "public": [
         "nrf5_log",
-        "nrf5_nrfx_common"
+        "nrf5_nrfx_common",
+        "nrf5_nrfx_prs"
       ]
     },
     "includes": {
@@ -674,7 +676,8 @@
     "dependencies": {
       "public": [
         "nrf5_log",
-        "nrf5_nrfx_common"
+        "nrf5_nrfx_common",
+        "nrf5_nrfx_prs"
       ]
     },
     "includes": {
@@ -707,7 +710,8 @@
     "dependencies": {
       "public": [
         "nrf5_log",
-        "nrf5_nrfx_common"
+        "nrf5_nrfx_common",
+        "nrf5_nrfx_prs"
       ]
     },
     "includes": {

--- a/ci/libraries_tests/nrf5_app_button/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_button/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_app_error/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_error/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_app_pwm/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_pwm/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_app_pwm
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_app_sdcard/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_sdcard/CMakeLists.txt
@@ -31,7 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
-  nrf5_app_error
+  nrf5_app_scheduler
   nrf5_app_sdcard
   nrf5_app_util_platform
   nrf5_atfifo
@@ -55,8 +55,8 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_memobj_fwd
   nrf5_mtx
   nrf5_nrfx_common
-  nrf5_nrfx_prs
   nrf5_nrfx_hal
+  nrf5_nrfx_spi
   nrf5_nrfx_spim
   nrf5_pwr_mgmt
   nrf5_queue

--- a/ci/libraries_tests/nrf5_app_sdcard/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_sdcard/CMakeLists.txt
@@ -56,6 +56,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_mtx
   nrf5_nrfx_common
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_nrfx_spi
   nrf5_nrfx_spim
   nrf5_pwr_mgmt

--- a/ci/libraries_tests/nrf5_app_sdcard/main.c
+++ b/ci/libraries_tests/nrf5_app_sdcard/main.c
@@ -1,5 +1,9 @@
 #include "app_sdcard.h"
 
+void app_error_handler_bare(uint32_t error_code)
+{
+}
+
 int main()
 {
     app_sdc_init(NULL, NULL);

--- a/ci/libraries_tests/nrf5_app_simple_timer/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_simple_timer/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_app_error
+  nrf5_app_scheduler
   nrf5_app_simple_timer
   nrf5_app_util_platform
   nrf5_atfifo

--- a/ci/libraries_tests/nrf5_app_uart/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_uart/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_uart
   nrf5_ext_fprintf

--- a/ci/libraries_tests/nrf5_app_uart/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_uart/CMakeLists.txt
@@ -55,6 +55,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_mtx
   nrf5_nrfx_common
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_nrfx_uart
   nrf5_nrfx_uarte
   nrf5_pwr_mgmt

--- a/ci/libraries_tests/nrf5_app_uart_fifo/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_uart_fifo/CMakeLists.txt
@@ -56,6 +56,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_mtx
   nrf5_nrfx_common
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_nrfx_uart
   nrf5_nrfx_uarte
   nrf5_pwr_mgmt

--- a/ci/libraries_tests/nrf5_app_uart_fifo/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_uart_fifo/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_uart
   nrf5_ext_fprintf

--- a/ci/libraries_tests/nrf5_app_usbd/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_usbd/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_clock
   nrf5_drv_power

--- a/ci/libraries_tests/nrf5_app_usbd_audio/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_usbd_audio/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_clock
   nrf5_drv_power

--- a/ci/libraries_tests/nrf5_app_usbd_cdc_acm/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_usbd_cdc_acm/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_clock
   nrf5_drv_power

--- a/ci/libraries_tests/nrf5_app_usbd_dummy/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_usbd_dummy/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_clock
   nrf5_drv_power

--- a/ci/libraries_tests/nrf5_app_usbd_hid/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_usbd_hid/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_clock
   nrf5_drv_power

--- a/ci/libraries_tests/nrf5_app_usbd_hid_generic/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_usbd_hid_generic/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_clock
   nrf5_drv_power

--- a/ci/libraries_tests/nrf5_app_usbd_hid_kbd/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_usbd_hid_kbd/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_clock
   nrf5_drv_power

--- a/ci/libraries_tests/nrf5_app_usbd_hid_mouse/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_usbd_hid_mouse/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_clock
   nrf5_drv_power

--- a/ci/libraries_tests/nrf5_app_usbd_msc/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_usbd_msc/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_clock
   nrf5_drv_power

--- a/ci/libraries_tests/nrf5_app_usbd_nrf_dfu_trigger/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_usbd_nrf_dfu_trigger/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_clock
   nrf5_drv_power

--- a/ci/libraries_tests/nrf5_app_usbd_serial_num/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_app_usbd_serial_num/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_clock
   nrf5_drv_power

--- a/ci/libraries_tests/nrf5_ble_advertising/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_advertising/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_ble_db_discovery/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_db_discovery/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_ble_gatt/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_gatt/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_ble_lesc/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_lesc/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_crypto
   nrf5_crypto_cc310_backend
   nrf5_delay

--- a/ci/libraries_tests/nrf5_ble_peer_data_storage/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_peer_data_storage/CMakeLists.txt
@@ -54,6 +54,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_ble_security_manager
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_ble_peer_manager/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_peer_manager/CMakeLists.txt
@@ -54,6 +54,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_ble_security_manager
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_ble_peer_manager_handler/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_peer_manager_handler/CMakeLists.txt
@@ -53,6 +53,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_ble_security_manager
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_ble_racp/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_racp/CMakeLists.txt
@@ -1,0 +1,38 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# WARNING: FILE GENERATED FROM ./ci/scripts/generate_cmake_tests.sh SCRIPT.
+
+cmake_minimum_required(VERSION 3.14)
+project(nrf5_ble_racp_test LANGUAGES C ASM)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../../cmake")
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME} "main.c")
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_ble_racp
+  nrf5_config
+  nrf5_mdk
+  nrf5_soc
+)

--- a/ci/libraries_tests/nrf5_ble_racp/main.c
+++ b/ci/libraries_tests/nrf5_ble_racp/main.c
@@ -1,0 +1,13 @@
+#include "ble_racp.h"
+
+void app_error_handler_bare(uint32_t error_code)
+{
+}
+
+int main()
+{
+    ble_racp_value_t value;
+    uint8_t data[] = {0};
+    ble_racp_encode(&value, data);
+    return 0;
+}

--- a/ci/libraries_tests/nrf5_ble_racp/sdk_config.h
+++ b/ci/libraries_tests/nrf5_ble_racp/sdk_config.h
@@ -1,0 +1,279 @@
+#ifndef SDK_CONFIG_H
+#define SDK_CONFIG_H
+
+#ifndef NRF_LOG_ENABLED
+#define NRF_LOG_ENABLED 0
+#endif
+
+// </h>
+//==========================================================
+
+// </h>
+//==========================================================
+
+// <h> nRF_SoftDevice
+
+//==========================================================
+// <e> NRF_SDH_BLE_ENABLED - nrf_sdh_ble - SoftDevice BLE event handler
+//==========================================================
+#ifndef NRF_SDH_BLE_ENABLED
+#define NRF_SDH_BLE_ENABLED 1
+#endif
+// <h> BLE Stack configuration - Stack configuration parameters
+
+// <i> The SoftDevice handler will configure the stack with these parameters when calling @ref nrf_sdh_ble_default_cfg_set.
+// <i> Other libraries might depend on these values; keep them up-to-date even if you are not explicitely calling @ref nrf_sdh_ble_default_cfg_set.
+//==========================================================
+// <o> NRF_SDH_BLE_GAP_DATA_LENGTH   <27-251>
+
+// <i> Requested BLE GAP data length to be negotiated.
+
+#ifndef NRF_SDH_BLE_GAP_DATA_LENGTH
+#define NRF_SDH_BLE_GAP_DATA_LENGTH 27
+#endif
+
+// <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links.
+#ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links.
+#ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count.
+// <i> Maximum number of total concurrent connections using the default configuration.
+
+#ifndef NRF_SDH_BLE_TOTAL_LINK_COUNT
+#define NRF_SDH_BLE_TOTAL_LINK_COUNT 1
+#endif
+
+// <o> NRF_SDH_BLE_GAP_EVENT_LENGTH - GAP event length.
+// <i> The time set aside for this connection on every connection interval in 1.25 ms units.
+
+#ifndef NRF_SDH_BLE_GAP_EVENT_LENGTH
+#define NRF_SDH_BLE_GAP_EVENT_LENGTH 6
+#endif
+
+// <o> NRF_SDH_BLE_GATT_MAX_MTU_SIZE - Static maximum MTU size.
+#ifndef NRF_SDH_BLE_GATT_MAX_MTU_SIZE
+#define NRF_SDH_BLE_GATT_MAX_MTU_SIZE 23
+#endif
+
+// <o> NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE - Attribute Table size in bytes. The size must be a multiple of 4.
+#ifndef NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE
+#define NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE 1408
+#endif
+
+// <o> NRF_SDH_BLE_VS_UUID_COUNT - The number of vendor-specific UUIDs.
+#ifndef NRF_SDH_BLE_VS_UUID_COUNT
+#define NRF_SDH_BLE_VS_UUID_COUNT 0
+#endif
+
+// <q> NRF_SDH_BLE_SERVICE_CHANGED  - Include the Service Changed characteristic in the Attribute Table.
+
+#ifndef NRF_SDH_BLE_SERVICE_CHANGED
+#define NRF_SDH_BLE_SERVICE_CHANGED 0
+#endif
+
+// <e> NRF_BLE_QWR_ENABLED - nrf_ble_qwr - Queued writes support module (prepare/execute write)
+//==========================================================
+#ifndef NRF_BLE_QWR_ENABLED
+#define NRF_BLE_QWR_ENABLED 1
+#endif
+// <o> NRF_BLE_QWR_MAX_ATTR - Maximum number of attribute handles that can be registered. This number must be adjusted according to the number of attributes for which Queued Writes will be enabled. If it is zero, the module will reject all Queued Write requests.
+#ifndef NRF_BLE_QWR_MAX_ATTR
+#define NRF_BLE_QWR_MAX_ATTR 1
+#endif
+
+// </e>
+
+// </e>
+
+// <e> NRF_SDH_SOC_ENABLED - nrf_sdh_soc - SoftDevice SoC event handler
+//==========================================================
+#ifndef NRF_SDH_SOC_ENABLED
+#define NRF_SDH_SOC_ENABLED 1
+#endif
+// <h> SoC Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_SOC_OBSERVER_PRIO_LEVELS - Total number of priority levels for SoC observers.
+// <i> This setting configures the number of priority levels available for the SoC event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_SOC_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_SOC_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <h> SoC Observers priorities - Invididual priorities
+
+// <e> NRF_SDH_ENABLED - nrf_sdh - SoftDevice handler
+//==========================================================
+#ifndef NRF_SDH_ENABLED
+#define NRF_SDH_ENABLED 1
+#endif
+// <h> Dispatch model
+
+// <i> This setting configures how Stack events are dispatched to the application.
+//==========================================================
+// <o> NRF_SDH_DISPATCH_MODEL
+
+// <i> NRF_SDH_DISPATCH_MODEL_INTERRUPT: SoftDevice events are passed to the application from the interrupt context.
+// <i> NRF_SDH_DISPATCH_MODEL_APPSH: SoftDevice events are scheduled using @ref app_scheduler.
+// <i> NRF_SDH_DISPATCH_MODEL_POLLING: SoftDevice events are to be fetched manually.
+// <0=> NRF_SDH_DISPATCH_MODEL_INTERRUPT
+// <1=> NRF_SDH_DISPATCH_MODEL_APPSH
+// <2=> NRF_SDH_DISPATCH_MODEL_POLLING
+
+#ifndef NRF_SDH_DISPATCH_MODEL
+#define NRF_SDH_DISPATCH_MODEL 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> Clock - SoftDevice clock configuration
+
+//==========================================================
+// <o> NRF_SDH_CLOCK_LF_SRC  - SoftDevice clock source.
+
+// <0=> NRF_CLOCK_LF_SRC_RC
+// <1=> NRF_CLOCK_LF_SRC_XTAL
+// <2=> NRF_CLOCK_LF_SRC_SYNTH
+
+#ifndef NRF_SDH_CLOCK_LF_SRC
+#define NRF_SDH_CLOCK_LF_SRC 1
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_CTIV - SoftDevice calibration timer interval.
+#ifndef NRF_SDH_CLOCK_LF_RC_CTIV
+#define NRF_SDH_CLOCK_LF_RC_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_TEMP_CTIV - SoftDevice calibration timer interval under constant temperature.
+// <i> How often (in number of calibration intervals) the RC oscillator shall be calibrated
+// <i>  if the temperature has not changed.
+
+#ifndef NRF_SDH_CLOCK_LF_RC_TEMP_CTIV
+#define NRF_SDH_CLOCK_LF_RC_TEMP_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_ACCURACY  - External clock accuracy used in the LL to compute timing.
+
+// <0=> NRF_CLOCK_LF_ACCURACY_250_PPM
+// <1=> NRF_CLOCK_LF_ACCURACY_500_PPM
+// <2=> NRF_CLOCK_LF_ACCURACY_150_PPM
+// <3=> NRF_CLOCK_LF_ACCURACY_100_PPM
+// <4=> NRF_CLOCK_LF_ACCURACY_75_PPM
+// <5=> NRF_CLOCK_LF_ACCURACY_50_PPM
+// <6=> NRF_CLOCK_LF_ACCURACY_30_PPM
+// <7=> NRF_CLOCK_LF_ACCURACY_20_PPM
+// <8=> NRF_CLOCK_LF_ACCURACY_10_PPM
+// <9=> NRF_CLOCK_LF_ACCURACY_5_PPM
+// <10=> NRF_CLOCK_LF_ACCURACY_2_PPM
+// <11=> NRF_CLOCK_LF_ACCURACY_1_PPM
+
+#ifndef NRF_SDH_CLOCK_LF_ACCURACY
+#define NRF_SDH_CLOCK_LF_ACCURACY 7
+#endif
+
+// <o> NRF_SDH_SOC_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which SoC events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have SoC events dispatched before or after other stack events, such as ANT or BLE.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_SOC_STACK_OBSERVER_PRIO
+#define NRF_SDH_SOC_STACK_OBSERVER_PRIO 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> SDH Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_REQ_OBSERVER_PRIO_LEVELS - Total number of priority levels for request observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice request event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_REQ_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_REQ_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_STATE_OBSERVER_PRIO_LEVELS - Total number of priority levels for state observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice state event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STATE_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STATE_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_STACK_OBSERVER_PRIO_LEVELS - Total number of priority levels for stack event observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice stack event handlers (ANT, BLE, SoC).
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STACK_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
+#endif
+
+#ifndef NRF_SECTION_ITER_ENABLED
+#define NRF_SECTION_ITER_ENABLED 1
+#endif
+
+// </h>
+//==========================================================
+
+// <h> BLE Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_BLE_OBSERVER_PRIO_LEVELS - Total number of priority levels for BLE observers.
+// <i> This setting configures the number of priority levels available for BLE event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_BLE_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_BLE_OBSERVER_PRIO_LEVELS 4
+#endif
+
+// <h> BLE Observers priorities - Invididual priorities
+
+//==========================================================
+// <o> BLE_ADV_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Advertising module.
+
+#ifndef BLE_ADV_BLE_OBSERVER_PRIO
+#define BLE_ADV_BLE_OBSERVER_PRIO 1
+#endif
+
+// <o> BLE_CONN_STATE_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Connection State module.
+
+#ifndef BLE_CONN_STATE_BLE_OBSERVER_PRIO
+#define BLE_CONN_STATE_BLE_OBSERVER_PRIO 0
+#endif
+
+// <o> NRF_SDH_STACK_OBSERVER_PRIO_LEVELS - Total number of priority levels for stack event observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice stack event handlers (ANT, BLE, SoC).
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STACK_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_BLE_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which BLE events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have BLE events dispatched before or after other stack events, such as ANT or SoC.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_BLE_STACK_OBSERVER_PRIO
+#define NRF_SDH_BLE_STACK_OBSERVER_PRIO 0
+#endif
+
+// </e>
+
+#ifndef BLE_RACP_ENABLED
+#define BLE_RACP_ENABLED 1
+#endif
+
+#endif // SDK_CONFIG_H

--- a/ci/libraries_tests/nrf5_ble_scan/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_scan/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_ble_srv_ancs_c/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_ancs_c/CMakeLists.txt
@@ -1,0 +1,73 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# WARNING: FILE GENERATED FROM ./ci/scripts/generate_cmake_tests.sh SCRIPT.
+
+cmake_minimum_required(VERSION 3.14)
+project(nrf5_ble_srv_ancs_c_test LANGUAGES C ASM)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../../cmake")
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME} "main.c")
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_balloc_fwd
+  nrf5_ble_common
+  nrf5_ble_db_discovery
+  nrf5_ble_srv_ancs_c
+  nrf5_cli
+  nrf5_cli_fwd
+  nrf5_config
+  nrf5_crc16
+  nrf5_delay
+  nrf5_ext_fprintf
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_log
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_memobj
+  nrf5_memobj_fwd
+  nrf5_mtx
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_pwr_mgmt
+  nrf5_queue
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+    nrf5_ble_gq
+  )
+endif()

--- a/ci/libraries_tests/nrf5_ble_srv_ancs_c/main.c
+++ b/ci/libraries_tests/nrf5_ble_srv_ancs_c/main.c
@@ -1,0 +1,15 @@
+#include "ancs_app_attr_get.h"
+#include "ancs_attr_parser.h"
+#include "nrf_ble_ancs_c.h"
+
+void app_error_handler_bare(uint32_t error_code)
+{
+}
+
+int main()
+{
+    ancs_c_app_attr_request(NULL, NULL, 0);
+    ancs_parse_get_attrs_response(NULL, NULL, 0);
+    ble_ancs_c_init(NULL, NULL);
+    return 0;
+}

--- a/ci/libraries_tests/nrf5_ble_srv_ancs_c/sdk_config.h
+++ b/ci/libraries_tests/nrf5_ble_srv_ancs_c/sdk_config.h
@@ -1,0 +1,493 @@
+#ifndef SDK_CONFIG_H
+#define SDK_CONFIG_H
+
+#ifndef NRF_LOG_ENABLED
+#define NRF_LOG_ENABLED 0
+#endif
+
+// </h>
+//==========================================================
+
+// </h>
+//==========================================================
+
+// <h> nRF_SoftDevice
+
+//==========================================================
+// <e> NRF_SDH_BLE_ENABLED - nrf_sdh_ble - SoftDevice BLE event handler
+//==========================================================
+#ifndef NRF_SDH_BLE_ENABLED
+#define NRF_SDH_BLE_ENABLED 1
+#endif
+// <h> BLE Stack configuration - Stack configuration parameters
+
+// <i> The SoftDevice handler will configure the stack with these parameters when calling @ref nrf_sdh_ble_default_cfg_set.
+// <i> Other libraries might depend on these values; keep them up-to-date even if you are not explicitely calling @ref nrf_sdh_ble_default_cfg_set.
+//==========================================================
+// <o> NRF_SDH_BLE_GAP_DATA_LENGTH   <27-251>
+
+// <i> Requested BLE GAP data length to be negotiated.
+
+#ifndef NRF_SDH_BLE_GAP_DATA_LENGTH
+#define NRF_SDH_BLE_GAP_DATA_LENGTH 27
+#endif
+
+// <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links.
+#ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links.
+#ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count.
+// <i> Maximum number of total concurrent connections using the default configuration.
+
+#ifndef NRF_SDH_BLE_TOTAL_LINK_COUNT
+#define NRF_SDH_BLE_TOTAL_LINK_COUNT 1
+#endif
+
+// <o> NRF_SDH_BLE_GAP_EVENT_LENGTH - GAP event length.
+// <i> The time set aside for this connection on every connection interval in 1.25 ms units.
+
+#ifndef NRF_SDH_BLE_GAP_EVENT_LENGTH
+#define NRF_SDH_BLE_GAP_EVENT_LENGTH 6
+#endif
+
+// <o> NRF_SDH_BLE_GATT_MAX_MTU_SIZE - Static maximum MTU size.
+#ifndef NRF_SDH_BLE_GATT_MAX_MTU_SIZE
+#define NRF_SDH_BLE_GATT_MAX_MTU_SIZE 23
+#endif
+
+// <o> NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE - Attribute Table size in bytes. The size must be a multiple of 4.
+#ifndef NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE
+#define NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE 1408
+#endif
+
+// <o> NRF_SDH_BLE_VS_UUID_COUNT - The number of vendor-specific UUIDs.
+#ifndef NRF_SDH_BLE_VS_UUID_COUNT
+#define NRF_SDH_BLE_VS_UUID_COUNT 0
+#endif
+
+// <q> NRF_SDH_BLE_SERVICE_CHANGED  - Include the Service Changed characteristic in the Attribute Table.
+
+#ifndef NRF_SDH_BLE_SERVICE_CHANGED
+#define NRF_SDH_BLE_SERVICE_CHANGED 0
+#endif
+
+// <e> NRF_SDH_SOC_ENABLED - nrf_sdh_soc - SoftDevice SoC event handler
+//==========================================================
+#ifndef NRF_SDH_SOC_ENABLED
+#define NRF_SDH_SOC_ENABLED 1
+#endif
+// <h> SoC Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_SOC_OBSERVER_PRIO_LEVELS - Total number of priority levels for SoC observers.
+// <i> This setting configures the number of priority levels available for the SoC event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_SOC_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_SOC_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <h> SoC Observers priorities - Invididual priorities
+
+// <e> NRF_SDH_ENABLED - nrf_sdh - SoftDevice handler
+//==========================================================
+#ifndef NRF_SDH_ENABLED
+#define NRF_SDH_ENABLED 1
+#endif
+
+// </h>
+//==========================================================
+
+// <h> Clock - SoftDevice clock configuration
+
+//==========================================================
+// <o> NRF_SDH_CLOCK_LF_SRC  - SoftDevice clock source.
+
+// <0=> NRF_CLOCK_LF_SRC_RC
+// <1=> NRF_CLOCK_LF_SRC_XTAL
+// <2=> NRF_CLOCK_LF_SRC_SYNTH
+
+#ifndef NRF_SDH_CLOCK_LF_SRC
+#define NRF_SDH_CLOCK_LF_SRC 1
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_CTIV - SoftDevice calibration timer interval.
+#ifndef NRF_SDH_CLOCK_LF_RC_CTIV
+#define NRF_SDH_CLOCK_LF_RC_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_TEMP_CTIV - SoftDevice calibration timer interval under constant temperature.
+// <i> How often (in number of calibration intervals) the RC oscillator shall be calibrated
+// <i>  if the temperature has not changed.
+
+#ifndef NRF_SDH_CLOCK_LF_RC_TEMP_CTIV
+#define NRF_SDH_CLOCK_LF_RC_TEMP_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_ACCURACY  - External clock accuracy used in the LL to compute timing.
+
+// <0=> NRF_CLOCK_LF_ACCURACY_250_PPM
+// <1=> NRF_CLOCK_LF_ACCURACY_500_PPM
+// <2=> NRF_CLOCK_LF_ACCURACY_150_PPM
+// <3=> NRF_CLOCK_LF_ACCURACY_100_PPM
+// <4=> NRF_CLOCK_LF_ACCURACY_75_PPM
+// <5=> NRF_CLOCK_LF_ACCURACY_50_PPM
+// <6=> NRF_CLOCK_LF_ACCURACY_30_PPM
+// <7=> NRF_CLOCK_LF_ACCURACY_20_PPM
+// <8=> NRF_CLOCK_LF_ACCURACY_10_PPM
+// <9=> NRF_CLOCK_LF_ACCURACY_5_PPM
+// <10=> NRF_CLOCK_LF_ACCURACY_2_PPM
+// <11=> NRF_CLOCK_LF_ACCURACY_1_PPM
+
+#ifndef NRF_SDH_CLOCK_LF_ACCURACY
+#define NRF_SDH_CLOCK_LF_ACCURACY 7
+#endif
+
+// <o> NRF_SDH_SOC_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which SoC events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have SoC events dispatched before or after other stack events, such as ANT or BLE.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_SOC_STACK_OBSERVER_PRIO
+#define NRF_SDH_SOC_STACK_OBSERVER_PRIO 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> BLE Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_BLE_OBSERVER_PRIO_LEVELS - Total number of priority levels for BLE observers.
+// <i> This setting configures the number of priority levels available for BLE event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_BLE_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_BLE_OBSERVER_PRIO_LEVELS 4
+#endif
+
+// <h> BLE Observers priorities - Invididual priorities
+
+//==========================================================
+// <o> BLE_ADV_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Advertising module.
+
+#ifndef BLE_ADV_BLE_OBSERVER_PRIO
+#define BLE_ADV_BLE_OBSERVER_PRIO 1
+#endif
+
+// <o> BLE_CONN_STATE_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Connection State module.
+
+#ifndef BLE_CONN_STATE_BLE_OBSERVER_PRIO
+#define BLE_CONN_STATE_BLE_OBSERVER_PRIO 0
+#endif
+
+// <o> NRF_SDH_STACK_OBSERVER_PRIO_LEVELS - Total number of priority levels for stack event observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice stack event handlers (ANT, BLE, SoC).
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STACK_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_BLE_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which BLE events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have BLE events dispatched before or after other stack events, such as ANT or SoC.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_BLE_STACK_OBSERVER_PRIO
+#define NRF_SDH_BLE_STACK_OBSERVER_PRIO 0
+#endif
+
+//---
+
+// <e> NRF_BLE_QWR_ENABLED - nrf_ble_qwr - Queued writes support module (prepare/execute write)
+//==========================================================
+#ifndef NRF_BLE_QWR_ENABLED
+#define NRF_BLE_QWR_ENABLED 1
+#endif
+// <o> NRF_BLE_QWR_MAX_ATTR - Maximum number of attribute handles that can be registered. This number must be adjusted according to the number of attributes for which Queued Writes will be enabled. If it is zero, the module will reject all Queued Write requests.
+#ifndef NRF_BLE_QWR_MAX_ATTR
+#define NRF_BLE_QWR_MAX_ATTR 1
+#endif
+
+// <q> NRF_SECTION_ITER_ENABLED  - nrf_section_iter - Section iterator
+
+#ifndef NRF_SECTION_ITER_ENABLED
+#define NRF_SECTION_ITER_ENABLED 1
+#endif
+
+// <e> APP_TIMER_ENABLED - app_timer - Application timer functionality
+//==========================================================
+#ifndef APP_TIMER_ENABLED
+#define APP_TIMER_ENABLED 1
+#endif
+// <o> APP_TIMER_CONFIG_RTC_FREQUENCY  - Configure RTC prescaler.
+
+// <0=> 32768 Hz
+// <1=> 16384 Hz
+// <3=> 8192 Hz
+// <7=> 4096 Hz
+// <15=> 2048 Hz
+// <31=> 1024 Hz
+
+#ifndef APP_TIMER_CONFIG_RTC_FREQUENCY
+#define APP_TIMER_CONFIG_RTC_FREQUENCY 1
+#endif
+
+// <o> APP_TIMER_CONFIG_IRQ_PRIORITY  - Interrupt priority
+
+// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef APP_TIMER_CONFIG_IRQ_PRIORITY
+#define APP_TIMER_CONFIG_IRQ_PRIORITY 6
+#endif
+
+// <o> APP_TIMER_CONFIG_OP_QUEUE_SIZE - Capacity of timer requests queue.
+// <i> Size of the queue depends on how many timers are used
+// <i> in the system, how often timers are started and overall
+// <i> system latency. If queue size is too small app_timer calls
+// <i> will fail.
+
+#ifndef APP_TIMER_CONFIG_OP_QUEUE_SIZE
+#define APP_TIMER_CONFIG_OP_QUEUE_SIZE 10
+#endif
+
+// <q> APP_TIMER_CONFIG_USE_SCHEDULER  - Enable scheduling app_timer events to app_scheduler
+
+#ifndef APP_TIMER_CONFIG_USE_SCHEDULER
+#define APP_TIMER_CONFIG_USE_SCHEDULER 0
+#endif
+
+// <q> APP_TIMER_KEEPS_RTC_ACTIVE  - Enable RTC always on
+
+// <i> If option is enabled RTC is kept running even if there is no active timers.
+// <i> This option can be used when app_timer is used for timestamping.
+
+#ifndef APP_TIMER_KEEPS_RTC_ACTIVE
+#define APP_TIMER_KEEPS_RTC_ACTIVE 0
+#endif
+
+// <o> APP_TIMER_SAFE_WINDOW_MS - Maximum possible latency (in milliseconds) of handling app_timer event.
+// <i> Maximum possible timeout that can be set is reduced by safe window.
+// <i> Example: RTC frequency 16384 Hz, maximum possible timeout 1024 seconds - APP_TIMER_SAFE_WINDOW_MS.
+// <i> Since RTC is not stopped when processor is halted in debugging session, this value
+// <i> must cover it if debugging is needed. It is possible to halt processor for APP_TIMER_SAFE_WINDOW_MS
+// <i> without corrupting app_timer behavior.
+
+#ifndef APP_TIMER_SAFE_WINDOW_MS
+#define APP_TIMER_SAFE_WINDOW_MS 300000
+#endif
+
+// <h> App Timer Legacy configuration - Legacy configuration.
+
+//==========================================================
+// <q> APP_TIMER_WITH_PROFILER  - Enable app_timer profiling
+
+#ifndef APP_TIMER_WITH_PROFILER
+#define APP_TIMER_WITH_PROFILER 0
+#endif
+
+// <q> APP_TIMER_CONFIG_SWI_NUMBER  - Configure SWI instance used.
+
+#ifndef APP_TIMER_CONFIG_SWI_NUMBER
+#define APP_TIMER_CONFIG_SWI_NUMBER 0
+#endif
+
+//---
+
+// <e> PEER_MANAGER_ENABLED - peer_manager - Peer Manager
+//==========================================================
+#ifndef PEER_MANAGER_ENABLED
+#define PEER_MANAGER_ENABLED 1
+#endif
+// <o> PM_MAX_REGISTRANTS - Number of event handlers that can be registered.
+#ifndef PM_MAX_REGISTRANTS
+#define PM_MAX_REGISTRANTS 3
+#endif
+
+// <o> PM_FLASH_BUFFERS - Number of internal buffers for flash operations.
+// <i> Decrease this value to lower RAM usage.
+
+#ifndef PM_FLASH_BUFFERS
+#define PM_FLASH_BUFFERS 4
+#endif
+
+// <q> PM_CENTRAL_ENABLED  - Enable/disable central-specific Peer Manager functionality.
+
+// <i> Enable/disable central-specific Peer Manager functionality.
+
+#ifndef PM_CENTRAL_ENABLED
+#define PM_CENTRAL_ENABLED 0
+#endif
+
+// <q> PM_SERVICE_CHANGED_ENABLED  - Enable/disable the service changed management for GATT server in Peer Manager.
+
+// <i> If not using a GATT server, or using a server wihout a service changed characteristic,
+// <i> disable this to save code space.
+
+#ifndef PM_SERVICE_CHANGED_ENABLED
+#define PM_SERVICE_CHANGED_ENABLED 1
+#endif
+
+// <q> PM_PEER_RANKS_ENABLED  - Enable/disable the peer rank management in Peer Manager.
+
+// <i> Set this to false to save code space if not using the peer rank API.
+
+#ifndef PM_PEER_RANKS_ENABLED
+#define PM_PEER_RANKS_ENABLED 1
+#endif
+
+// <q> PM_LESC_ENABLED  - Enable/disable LESC support in Peer Manager.
+
+// <i> If set to true, you need to call nrf_ble_lesc_request_handler() in the main loop to respond to LESC-related BLE events. If LESC support is not required, set this to false to save code space.
+
+#ifndef PM_LESC_ENABLED
+#define PM_LESC_ENABLED 0
+#endif
+
+// <e> PM_RA_PROTECTION_ENABLED - Enable/disable protection against repeated pairing attempts in Peer Manager.
+//==========================================================
+#ifndef PM_RA_PROTECTION_ENABLED
+#define PM_RA_PROTECTION_ENABLED 1
+#endif
+// <o> PM_RA_PROTECTION_TRACKED_PEERS_NUM - Maximum number of peers whose authorization status can be tracked.
+#ifndef PM_RA_PROTECTION_TRACKED_PEERS_NUM
+#define PM_RA_PROTECTION_TRACKED_PEERS_NUM 8
+#endif
+
+// <o> PM_RA_PROTECTION_MIN_WAIT_INTERVAL - Minimum waiting interval (in ms) before a new pairing attempt can be initiated.
+#ifndef PM_RA_PROTECTION_MIN_WAIT_INTERVAL
+#define PM_RA_PROTECTION_MIN_WAIT_INTERVAL 4000
+#endif
+
+// <o> PM_RA_PROTECTION_MAX_WAIT_INTERVAL - Maximum waiting interval (in ms) before a new pairing attempt can be initiated.
+#ifndef PM_RA_PROTECTION_MAX_WAIT_INTERVAL
+#define PM_RA_PROTECTION_MAX_WAIT_INTERVAL 64000
+#endif
+
+// <o> PM_RA_PROTECTION_REWARD_PERIOD - Reward period (in ms).
+// <i> The waiting interval is gradually decreased when no new failed pairing attempts are made during reward period.
+
+#ifndef PM_RA_PROTECTION_REWARD_PERIOD
+#define PM_RA_PROTECTION_REWARD_PERIOD 10000
+#endif
+
+// </e>
+
+// <o> PM_HANDLER_SEC_DELAY_MS - Delay before starting security.
+// <i>  This might be necessary for interoperability reasons, especially as peripheral.
+
+#ifndef PM_HANDLER_SEC_DELAY_MS
+#define PM_HANDLER_SEC_DELAY_MS 0
+#endif
+
+// </e>
+
+// <e> NRF_BLE_GQ_ENABLED - nrf_ble_gq - BLE GATT Queue Module
+//==========================================================
+#ifndef NRF_BLE_GQ_ENABLED
+#define NRF_BLE_GQ_ENABLED 1
+#endif
+// <o> NRF_BLE_GQ_DATAPOOL_ELEMENT_SIZE - Default size of a single element in the pool of memory objects.
+#ifndef NRF_BLE_GQ_DATAPOOL_ELEMENT_SIZE
+#define NRF_BLE_GQ_DATAPOOL_ELEMENT_SIZE 20
+#endif
+
+// <o> NRF_BLE_GQ_DATAPOOL_ELEMENT_COUNT - Default number of elements in the pool of memory objects.
+#ifndef NRF_BLE_GQ_DATAPOOL_ELEMENT_COUNT
+#define NRF_BLE_GQ_DATAPOOL_ELEMENT_COUNT 8
+#endif
+
+// <o> NRF_BLE_GQ_GATTC_WRITE_MAX_DATA_LEN - Maximal size of the data inside GATTC write request (in bytes).
+#ifndef NRF_BLE_GQ_GATTC_WRITE_MAX_DATA_LEN
+#define NRF_BLE_GQ_GATTC_WRITE_MAX_DATA_LEN 16
+#endif
+
+// <o> NRF_BLE_GQ_GATTS_HVX_MAX_DATA_LEN - Maximal size of the data inside GATTC notification or indication request (in bytes).
+#ifndef NRF_BLE_GQ_GATTS_HVX_MAX_DATA_LEN
+#define NRF_BLE_GQ_GATTS_HVX_MAX_DATA_LEN 16
+#endif
+
+// <e> NRF_BALLOC_ENABLED - nrf_balloc - Block allocator module
+//==========================================================
+#ifndef NRF_BALLOC_ENABLED
+#define NRF_BALLOC_ENABLED 1
+#endif
+// <e> NRF_BALLOC_CONFIG_DEBUG_ENABLED - Enables debug mode in the module.
+//==========================================================
+#ifndef NRF_BALLOC_CONFIG_DEBUG_ENABLED
+#define NRF_BALLOC_CONFIG_DEBUG_ENABLED 0
+#endif
+// <o> NRF_BALLOC_CONFIG_HEAD_GUARD_WORDS - Number of words used as head guard.  <0-255>
+
+#ifndef NRF_BALLOC_CONFIG_HEAD_GUARD_WORDS
+#define NRF_BALLOC_CONFIG_HEAD_GUARD_WORDS 1
+#endif
+
+// <o> NRF_BALLOC_CONFIG_TAIL_GUARD_WORDS - Number of words used as tail guard.  <0-255>
+
+#ifndef NRF_BALLOC_CONFIG_TAIL_GUARD_WORDS
+#define NRF_BALLOC_CONFIG_TAIL_GUARD_WORDS 1
+#endif
+
+// <q> NRF_BALLOC_CONFIG_BASIC_CHECKS_ENABLED  - Enables basic checks in this module.
+
+#ifndef NRF_BALLOC_CONFIG_BASIC_CHECKS_ENABLED
+#define NRF_BALLOC_CONFIG_BASIC_CHECKS_ENABLED 0
+#endif
+
+// <q> NRF_BALLOC_CONFIG_DOUBLE_FREE_CHECK_ENABLED  - Enables double memory free check in this module.
+
+#ifndef NRF_BALLOC_CONFIG_DOUBLE_FREE_CHECK_ENABLED
+#define NRF_BALLOC_CONFIG_DOUBLE_FREE_CHECK_ENABLED 0
+#endif
+
+// <q> NRF_BALLOC_CONFIG_DATA_TRASHING_CHECK_ENABLED  - Enables free memory corruption check in this module.
+
+#ifndef NRF_BALLOC_CONFIG_DATA_TRASHING_CHECK_ENABLED
+#define NRF_BALLOC_CONFIG_DATA_TRASHING_CHECK_ENABLED 0
+#endif
+
+// <q> NRF_BALLOC_CLI_CMDS  - Enable CLI commands specific to the module
+
+#ifndef NRF_BALLOC_CLI_CMDS
+#define NRF_BALLOC_CLI_CMDS 0
+#endif
+
+// </e>
+
+// </e>
+
+// <e> NRF_QUEUE_ENABLED - nrf_queue - Queue module
+//==========================================================
+#ifndef NRF_QUEUE_ENABLED
+#define NRF_QUEUE_ENABLED 1
+#endif
+
+//---
+
+#ifndef BLE_ANCS_C_ENABLED
+#define BLE_ANCS_C_ENABLED 1
+#endif
+
+#ifndef BLE_DB_DISCOVERY_ENABLED
+#define BLE_DB_DISCOVERY_ENABLED 1
+#endif
+
+#endif // SDK_CONFIG_H

--- a/ci/libraries_tests/nrf5_ble_srv_ans_c/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_ans_c/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_ble_srv_cgms/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_cgms/CMakeLists.txt
@@ -1,0 +1,64 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# WARNING: FILE GENERATED FROM ./ci/scripts/generate_cmake_tests.sh SCRIPT.
+
+cmake_minimum_required(VERSION 3.14)
+project(nrf5_ble_srv_cgms_test LANGUAGES C ASM)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../../cmake")
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME} "main.c")
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_racp
+  nrf5_ble_srv_cgms
+  nrf5_config
+  nrf5_delay
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+    nrf5_balloc
+    nrf5_balloc_fwd
+    nrf5_ble_gq
+    nrf5_cli_fwd
+    nrf5_ext_fprintf
+    nrf5_memobj
+    nrf5_memobj_fwd
+    nrf5_queue
+  )
+endif()

--- a/ci/libraries_tests/nrf5_ble_srv_cgms/main.c
+++ b/ci/libraries_tests/nrf5_ble_srv_cgms/main.c
@@ -1,0 +1,19 @@
+#include "cgms_db.h"
+#include "cgms_meas.h"
+#include "cgms_racp.h"
+#include "cgms_socp.h"
+#include "cgms_sst.h"
+
+void app_error_handler_bare(uint32_t error_code)
+{
+}
+
+int main()
+{
+    cgms_db_init();
+    cgms_meas_char_add(NULL);
+    cgms_racp_char_add(NULL);
+    cgms_socp_char_add(NULL);
+    cgms_sst_char_add(NULL);
+    return 0;
+}

--- a/ci/libraries_tests/nrf5_ble_srv_cgms/sdk_config.h
+++ b/ci/libraries_tests/nrf5_ble_srv_cgms/sdk_config.h
@@ -1,0 +1,229 @@
+#ifndef SDK_CONFIG_H
+#define SDK_CONFIG_H
+
+#ifndef NRF_LOG_ENABLED
+#define NRF_LOG_ENABLED 0
+#endif
+
+// </h>
+//==========================================================
+
+// </h>
+//==========================================================
+
+// <h> nRF_SoftDevice
+
+//==========================================================
+// <e> NRF_SDH_BLE_ENABLED - nrf_sdh_ble - SoftDevice BLE event handler
+//==========================================================
+#ifndef NRF_SDH_BLE_ENABLED
+#define NRF_SDH_BLE_ENABLED 1
+#endif
+// <h> BLE Stack configuration - Stack configuration parameters
+
+// <i> The SoftDevice handler will configure the stack with these parameters when calling @ref nrf_sdh_ble_default_cfg_set.
+// <i> Other libraries might depend on these values; keep them up-to-date even if you are not explicitely calling @ref nrf_sdh_ble_default_cfg_set.
+//==========================================================
+// <o> NRF_SDH_BLE_GAP_DATA_LENGTH   <27-251>
+
+// <i> Requested BLE GAP data length to be negotiated.
+
+#ifndef NRF_SDH_BLE_GAP_DATA_LENGTH
+#define NRF_SDH_BLE_GAP_DATA_LENGTH 27
+#endif
+
+// <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links.
+#ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links.
+#ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count.
+// <i> Maximum number of total concurrent connections using the default configuration.
+
+#ifndef NRF_SDH_BLE_TOTAL_LINK_COUNT
+#define NRF_SDH_BLE_TOTAL_LINK_COUNT 1
+#endif
+
+// <o> NRF_SDH_BLE_GAP_EVENT_LENGTH - GAP event length.
+// <i> The time set aside for this connection on every connection interval in 1.25 ms units.
+
+#ifndef NRF_SDH_BLE_GAP_EVENT_LENGTH
+#define NRF_SDH_BLE_GAP_EVENT_LENGTH 6
+#endif
+
+// <o> NRF_SDH_BLE_GATT_MAX_MTU_SIZE - Static maximum MTU size.
+#ifndef NRF_SDH_BLE_GATT_MAX_MTU_SIZE
+#define NRF_SDH_BLE_GATT_MAX_MTU_SIZE 23
+#endif
+
+// <o> NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE - Attribute Table size in bytes. The size must be a multiple of 4.
+#ifndef NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE
+#define NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE 1408
+#endif
+
+// <o> NRF_SDH_BLE_VS_UUID_COUNT - The number of vendor-specific UUIDs.
+#ifndef NRF_SDH_BLE_VS_UUID_COUNT
+#define NRF_SDH_BLE_VS_UUID_COUNT 0
+#endif
+
+// <q> NRF_SDH_BLE_SERVICE_CHANGED  - Include the Service Changed characteristic in the Attribute Table.
+
+#ifndef NRF_SDH_BLE_SERVICE_CHANGED
+#define NRF_SDH_BLE_SERVICE_CHANGED 0
+#endif
+
+// <e> NRF_SDH_SOC_ENABLED - nrf_sdh_soc - SoftDevice SoC event handler
+//==========================================================
+#ifndef NRF_SDH_SOC_ENABLED
+#define NRF_SDH_SOC_ENABLED 1
+#endif
+// <h> SoC Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_SOC_OBSERVER_PRIO_LEVELS - Total number of priority levels for SoC observers.
+// <i> This setting configures the number of priority levels available for the SoC event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_SOC_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_SOC_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <h> SoC Observers priorities - Invididual priorities
+
+// <e> NRF_SDH_ENABLED - nrf_sdh - SoftDevice handler
+//==========================================================
+#ifndef NRF_SDH_ENABLED
+#define NRF_SDH_ENABLED 1
+#endif
+
+// </h>
+//==========================================================
+
+// <h> Clock - SoftDevice clock configuration
+
+//==========================================================
+// <o> NRF_SDH_CLOCK_LF_SRC  - SoftDevice clock source.
+
+// <0=> NRF_CLOCK_LF_SRC_RC
+// <1=> NRF_CLOCK_LF_SRC_XTAL
+// <2=> NRF_CLOCK_LF_SRC_SYNTH
+
+#ifndef NRF_SDH_CLOCK_LF_SRC
+#define NRF_SDH_CLOCK_LF_SRC 1
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_CTIV - SoftDevice calibration timer interval.
+#ifndef NRF_SDH_CLOCK_LF_RC_CTIV
+#define NRF_SDH_CLOCK_LF_RC_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_TEMP_CTIV - SoftDevice calibration timer interval under constant temperature.
+// <i> How often (in number of calibration intervals) the RC oscillator shall be calibrated
+// <i>  if the temperature has not changed.
+
+#ifndef NRF_SDH_CLOCK_LF_RC_TEMP_CTIV
+#define NRF_SDH_CLOCK_LF_RC_TEMP_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_ACCURACY  - External clock accuracy used in the LL to compute timing.
+
+// <0=> NRF_CLOCK_LF_ACCURACY_250_PPM
+// <1=> NRF_CLOCK_LF_ACCURACY_500_PPM
+// <2=> NRF_CLOCK_LF_ACCURACY_150_PPM
+// <3=> NRF_CLOCK_LF_ACCURACY_100_PPM
+// <4=> NRF_CLOCK_LF_ACCURACY_75_PPM
+// <5=> NRF_CLOCK_LF_ACCURACY_50_PPM
+// <6=> NRF_CLOCK_LF_ACCURACY_30_PPM
+// <7=> NRF_CLOCK_LF_ACCURACY_20_PPM
+// <8=> NRF_CLOCK_LF_ACCURACY_10_PPM
+// <9=> NRF_CLOCK_LF_ACCURACY_5_PPM
+// <10=> NRF_CLOCK_LF_ACCURACY_2_PPM
+// <11=> NRF_CLOCK_LF_ACCURACY_1_PPM
+
+#ifndef NRF_SDH_CLOCK_LF_ACCURACY
+#define NRF_SDH_CLOCK_LF_ACCURACY 7
+#endif
+
+// <o> NRF_SDH_SOC_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which SoC events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have SoC events dispatched before or after other stack events, such as ANT or BLE.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_SOC_STACK_OBSERVER_PRIO
+#define NRF_SDH_SOC_STACK_OBSERVER_PRIO 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> BLE Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_BLE_OBSERVER_PRIO_LEVELS - Total number of priority levels for BLE observers.
+// <i> This setting configures the number of priority levels available for BLE event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_BLE_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_BLE_OBSERVER_PRIO_LEVELS 4
+#endif
+
+// <h> BLE Observers priorities - Invididual priorities
+
+//==========================================================
+// <o> BLE_ADV_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Advertising module.
+
+#ifndef BLE_ADV_BLE_OBSERVER_PRIO
+#define BLE_ADV_BLE_OBSERVER_PRIO 1
+#endif
+
+// <o> BLE_CONN_STATE_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Connection State module.
+
+#ifndef BLE_CONN_STATE_BLE_OBSERVER_PRIO
+#define BLE_CONN_STATE_BLE_OBSERVER_PRIO 0
+#endif
+
+// <o> NRF_SDH_STACK_OBSERVER_PRIO_LEVELS - Total number of priority levels for stack event observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice stack event handlers (ANT, BLE, SoC).
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STACK_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_BLE_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which BLE events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have BLE events dispatched before or after other stack events, such as ANT or SoC.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_BLE_STACK_OBSERVER_PRIO
+#define NRF_SDH_BLE_STACK_OBSERVER_PRIO 0
+#endif
+
+//---
+
+// <e> NRF_BLE_QWR_ENABLED - nrf_ble_qwr - Queued writes support module (prepare/execute write)
+//==========================================================
+#ifndef NRF_BLE_QWR_ENABLED
+#define NRF_BLE_QWR_ENABLED 1
+#endif
+// <o> NRF_BLE_QWR_MAX_ATTR - Maximum number of attribute handles that can be registered. This number must be adjusted according to the number of attributes for which Queued Writes will be enabled. If it is zero, the module will reject all Queued Write requests.
+#ifndef NRF_BLE_QWR_MAX_ATTR
+#define NRF_BLE_QWR_MAX_ATTR 1
+#endif
+
+// <q> NRF_SECTION_ITER_ENABLED  - nrf_section_iter - Section iterator
+
+#ifndef NRF_SECTION_ITER_ENABLED
+#define NRF_SECTION_ITER_ENABLED 1
+#endif
+
+//---
+
+#endif // SDK_CONFIG_H

--- a/ci/libraries_tests/nrf5_ble_srv_cts_c/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_cts_c/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_ble_srv_eddystone/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_eddystone/CMakeLists.txt
@@ -1,0 +1,93 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# WARNING: FILE GENERATED FROM ./ci/scripts/generate_cmake_tests.sh SCRIPT.
+# WARNING: This test contains custom patch to allow compilation. Please edit
+#          above script if there is a need to do it.
+
+cmake_minimum_required(VERSION 3.14)
+project(nrf5_ble_srv_eddystone_test LANGUAGES C ASM)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../../cmake")
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME} "main.c")
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_balloc_fwd
+  nrf5_ble_common
+  nrf5_ble_srv_eddystone
+  nrf5_cli
+  nrf5_cli_fwd
+  nrf5_config
+  nrf5_crc16
+  nrf5_crypto
+  nrf5_crypto_cifra_backend
+  nrf5_crypto_mbedtls_backend
+  nrf5_crypto_nrf_hw_backend
+  nrf5_crypto_oberon_backend
+  nrf5_delay
+  nrf5_drv_rng
+  nrf5_drv_saadc
+  nrf5_ext_cc310_bl_fwd
+  nrf5_ext_cc310_fwd
+  nrf5_ext_cifra_aes128_eax
+  nrf5_ext_cifra_aes128_eax_fwd
+  nrf5_ext_fprintf
+  nrf5_ext_mbedcrypto
+  nrf5_ext_mbedtls
+  nrf5_ext_mbedtls_fwd
+  nrf5_ext_mbedx509
+  nrf5_ext_micro_ecc_fwd
+  nrf5_ext_oberon_fwd
+  nrf5_ext_optiga_fwd
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_fstorage_sd
+  nrf5_log
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_mem_manager
+  nrf5_memobj
+  nrf5_memobj_fwd
+  nrf5_mtx
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_nrfx_rng
+  nrf5_nrfx_saadc
+  nrf5_pwr_mgmt
+  nrf5_queue
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_sha256_fwd
+  nrf5_soc
+  nrf5_stack_info
+  nrf5_strerror
+)

--- a/ci/libraries_tests/nrf5_ble_srv_eddystone/es_app_config.h
+++ b/ci/libraries_tests/nrf5_ble_srv_eddystone/es_app_config.h
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2016 - 2019, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 4. This software, with or without modification, must only be used with a
+ *    Nordic Semiconductor ASA integrated circuit.
+ *
+ * 5. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+#ifndef ES_APP_CONFIG_H__
+#define ES_APP_CONFIG_H__
+
+#include "es.h"
+// #include "boards.h"
+
+/**
+ * @file
+ * @defgroup eddystone_app_config Application configuration
+ * @brief Configuration settings for the application.
+ * @details These configuration settings are defined in the application.
+ * You can find the configuration file at
+ * <tt>examples\ble_peripheral\ble_app_eddystone\es_app_config.h</tt>.
+ * @ingroup eddystone
+ * @{
+ */
+
+// EID security
+#define MAC_RANDOMIZED //!< Configuration option to specify whether the BLE address should be randomized when advertising EIDs.
+
+#define APP_CONFIG_LOCK_CODE {0xFF, 0xFF, 0xFF, 0xFF, \
+                              0xFF, 0xFF, 0xFF, 0xFF, \
+                              0xFF, 0xFF, 0xFF, 0xFF, \
+                              0xFF, 0xFF, 0xFF, 0xFF} //!< Beacon lock code. @warning This lock code must be changed before going to production.
+
+#ifdef NRF52_SERIES
+#define APP_CONFIG_CALIBRATED_RANGING_DATA {-49, -39, -29, -24, -19, -14, -9, -7, -5}   //!< Calibrated TX power at 0 m. See the nRF52 Product Specification for corresponding TX values.
+#elif NRF51
+#define APP_CONFIG_CALIBRATED_RANGING_DATA {-39, -26, -23, -18, -13, -12, -9, -2}       //!< Calibrated TX power at 0 m. See the nRF51 Product Specification for corresponding TX values.
+#else
+#error MISSING CALIBRATED DATA
+#endif
+
+#define APP_CONFIG_TLM_TEMP_VBATT_UPDATE_INTERVAL_SECONDS   10                          //!< How often should the data in the TLM frame be updated.
+#define APP_CONFIG_TLM_ADV_INTERLEAVE_RATIO                 5                           //!< How often should the TLM frame be advertised.
+
+
+#define APP_CONFIG_ADV_INTERVAL_MS_MAX                      16384                       //!< Maximum allowed advertisement interval. Can be undefined without int
+#define APP_CONFIG_ADV_FRAME_SPACING_MS_MIN                 500                         //!< Minimum time between advertisement frames. Imposes limit on minumum accepted advertisement interval.
+#ifdef NRF52_SERIES
+#define APP_CONFIG_ADV_FRAME_ETLM_SPACING_MS                300                         //!< The time that is reqired for preparing an eTLM slot. Imposes limit on minimum accepted advertisement interval.
+#else
+#error MISSING ETLM DELAY TIMING
+#endif
+
+#define ES_STOPWATCH_MAX_USERS                              4                           //!< Maximum amount of users that can be registered with the es_stopwatch module.
+
+
+#define DEBUG_TIMING_INIT_VALUE                             65280                       //!< Initial time (as recommended by Google) to test the TK rollover behavior.
+#define APP_CONFIG_TIMING_INIT_VALUE                        DEBUG_TIMING_INIT_VALUE     //!< Initializing value for the timing value of security slots.
+
+#define APP_CONFIG_TLM_TEMP_INTERVAL_SECONDS                (30)                        //!< How often should the temperature of the beacon be updated when TLM slot is configured.
+#define APP_CONFIG_TLM_VBATT_INTERVAL_SECONDS               (30)                        //!< How often should the battery voltage of the beacon be updated when TLM slot is configured.
+
+// HW CONFIGS
+#define BUTTON_REGISTRATION                                 BUTTON_1                    //!< Button to push when putting the beacon in registration mode.
+#define USE_ECB_ENCRYPT_HW                                  1                           //!< Configuration option to use the hardware peripheral (1) or the software library (0) for ECB encryption (decryption always uses the software library).
+
+
+// BLE CONFIGS
+#define APP_DEVICE_NAME                                     "nRF5x_Eddystone"           //!< Advertised device name in the scan response when in connectable mode.
+#define IS_SRVC_CHANGED_CHARACT_PRESENT                     0                           //!< Information whether the service changed characteristic is available. If it is not enabled, the server's database cannot be changed for the lifetime of the device.
+#define MAX_ADV_INTERVAL                                    (10240)                     //!< Maximum connection interval (in ms).
+#define MIN_CONN_ADV_INTERVAL                               (20)                        //!< Minimum connection interval (in ms).
+#define MIN_NON_CONN_ADV_INTERVAL                           (100)                       //!< Minimum advertisement interval for non-connectable advertisements (in ms).
+
+#define CENTRAL_LINK_COUNT                                  0                           //!< Number of central links used by the application. When changing this number, remember to adjust the RAM settings.
+#define PERIPHERAL_LINK_COUNT                               1                           //!< Number of peripheral links used by the application. When changing this number, remember to adjust the RAM settings.
+
+#define APP_CFG_NON_CONN_ADV_TIMEOUT                        0                           //!< Time for which the device must be advertising in non-connectable mode (in seconds). 0 disables the time-out.
+#define APP_CFG_NON_CONN_ADV_INTERVAL_MS                    1000                        //!< The advertising interval for non-connectable advertisement (in milliseconds). This value can vary between 100 ms and 10.24 s.
+#define APP_CFG_CONNECTABLE_ADV_TIMEOUT                     6000                        //!< Time for which the device must be advertising in connectable mode (in milliseconds). 0 disables the time-out.
+#define APP_CFG_CONNECTABLE_ADV_INTERVAL_MS                 100                         //!< The advertising interval for connectable advertisement (in milliseconds). This value can vary between 20 ms and 10.24 s.
+
+#define APP_CFG_DEFAULT_RADIO_TX_POWER                      0x00                        //!< Default TX power of the radio.
+
+#define MIN_CONN_INTERVAL                   MSEC_TO_UNITS(50, UNIT_1_25_MS)             //!< Minimum acceptable connection interval (20 ms). The connection interval uses 1.25 ms units.
+#define MAX_CONN_INTERVAL                   MSEC_TO_UNITS(90, UNIT_1_25_MS)             //!< Maximum acceptable connection interval (75 ms). The connection interval uses 1.25 ms units.
+#define SLAVE_LATENCY                       0                                           //!< Slave latency.
+#define CONN_SUP_TIMEOUT                    MSEC_TO_UNITS(4000, UNIT_10_MS)             //!< Connection supervision time-out (4 seconds). The supervision time-out uses 10 ms units.
+#define FIRST_CONN_PARAMS_UPDATE_DELAY      APP_TIMER_TICKS(5000)                       //!< Time from initiating an event (connection or start of notification) to the first time @ref sd_ble_gap_conn_param_update is called (5 seconds).
+#define NEXT_CONN_PARAMS_UPDATE_DELAY       APP_TIMER_TICKS(30000)                      //!< Time between each call to @ref sd_ble_gap_conn_param_update after the first call (30 seconds).
+#define MAX_CONN_PARAMS_UPDATE_COUNT        3                                           //!< Number of attempts before giving up the connection parameter negotiation.
+
+
+// ES CONFIGS
+#define APP_MAX_ADV_SLOTS                   5                                           //!< Maximum number of advertisement slots.
+#define APP_MAX_EID_SLOTS                   APP_MAX_ADV_SLOTS                           /**< @brief Maximum number of EID slots.
+                                                                                         * @note The maximum number of EID slots must be equal to the maximum number of advertisement slots (@ref APP_MAX_ADV_SLOTS). If your application
+                                                                                         * does not adhere to this convention, you must modify the @ref eddystone_security module, because the security module maps the security slots'
+                                                                                         * slot numbers 1 to 1 to the slots'. */
+
+// Broadcast Capabilities
+#define APP_IS_VARIABLE_ADV_SUPPORTED       ESCS_BROADCAST_VAR_ADV_SUPPORTED_No         //!< Information whether variable advertisement intervals are supported.
+#define APP_IS_VARIABLE_TX_POWER_SUPPORTED  ESCS_BROADCAST_VAR_TX_POWER_SUPPORTED_Yes   //!< Information whether variable advertisement TX power is supported.
+
+#define APP_IS_UID_SUPPORTED                ESCS_FRAME_TYPE_UID_SUPPORTED_Yes           //!< Information whether the UID frame is supported.
+#define APP_IS_URL_SUPPORTED                ESCS_FRAME_TYPE_URL_SUPPORTED_Yes           //!< Information whether the URL frame is supported.
+#define APP_IS_TLM_SUPPORTED                ESCS_FRAME_TYPE_TLM_SUPPORTED_Yes           //!< Information whether the TLM frame is supported.
+#define APP_IS_EID_SUPPORTED                ESCS_FRAME_TYPE_EID_SUPPORTED_Yes           //!< Information whether the EID frame is supported.
+
+// Remain connectable
+#define APP_IS_REMAIN_CONNECTABLE_SUPPORTED ESCS_FUNCT_REMAIN_CONNECTABLE_SUPPORTED_Yes //!< Information whether the 'remain connectable' option is supported.
+
+// Eddystone common data
+#define APP_ES_UUID                         0xFEAA                                      //!< UUID for Eddystone beacons according to specification.
+
+// Eddystone UID data
+#define APP_ES_UID_FRAME_TYPE               ES_FRAME_TYPE_UID                           //!< UID frame type (fixed at 0x00).
+#define APP_ES_UID_NAMESPACE                0xAA, 0xAA, 0xBB, 0xBB, \
+                                            0xCC, 0xCC, 0xDD, 0xDD, \
+                                            0xEE, 0xEE                                  //!< Mock values for 10-byte Eddystone UID ID namespace.
+#define APP_ES_UID_ID                       0x01, 0x02, 0x03, 0x04, \
+                                            0x05, 0x06                                  //!< Mock values for 6-byte Eddystone UID ID instance.
+#define APP_ES_UID_RFU                      0x00, 0x00                                  //!< Reserved for future use according to specification.
+
+// Eddystone URL data
+#define APP_ES_URL_FRAME_TYPE               ES_FRAME_TYPE_URL                           //!< URL Frame type (fixed at 0x10).
+#define APP_ES_URL_SCHEME                   0x01                                        //!< URL prefix scheme according to specification (0x01 = "https://www").
+#define APP_ES_URL_URL                      0x6e, 0x6f, 0x72, 0x64, \
+                                            0x69, 0x63, 0x73, 0x65, \
+                                            0x6d,0x69, 0x00                             //!< "nordicsemi.com". Last byte suffix 0x00 = ".com" according to specification.
+
+#define DEFAULT_FRAME_TYPE                  APP_ES_URL_FRAME_TYPE                       //!< Frame type of default frame.
+#define DEFAULT_FRAME_TX_POWER              0x00                                        //!< Default frame TX power.
+
+/** @brief This value should mimic the data that would be written to the RW ADV Slot characteristic (for example, no RSSI for UID). */
+#define DEFAULT_FRAME_DATA                  {DEFAULT_FRAME_TYPE, DEFAULT_FRAME_TX_POWER, APP_ES_URL_SCHEME, APP_ES_URL_URL}
+#define DEFAULT_FRAME_LENGTH                14                                          //!< 1 - Frame Type, 1 - TX - power 1 - URL Scheme, URL - 11 = 14
+
+// SCHEDULER CONFIGS
+#define SCHED_MAX_EVENT_DATA_SIZE           APP_TIMER_SCHED_EVENT_DATA_SIZE             //!< Maximum size of the scheduler event data.
+#define SCHED_QUEUE_SIZE                    10                                          //!< Size of the scheduler queue.
+
+
+/**
+ * @}
+ */
+
+#endif // ES_APP_CONFIG_H__

--- a/ci/libraries_tests/nrf5_ble_srv_eddystone/main.c
+++ b/ci/libraries_tests/nrf5_ble_srv_eddystone/main.c
@@ -1,0 +1,45 @@
+#include <stddef.h>
+#include "nrf_ble_es.h"
+#include "es_adv.h"
+#include "es_adv_frame.h"
+#include "es_adv_timing.h"
+#include "es_adv_timing_resolver.h"
+#include "es_battery_voltage.h"
+#include "es_flash.h"
+#include "es_gatts.h"
+#include "es_gatts_read.h"
+#include "es_gatts_write.h"
+#include "es_security.h"
+#include "es_slot.h"
+#include "es_slot_reg.h"
+#include "es_stopwatch.h"
+#include "es_tlm.h"
+#include "es_util.h"
+
+void app_error_handler_bare(uint32_t error_code)
+{
+}
+
+void app_error_fault_handler(uint32_t id, uint32_t pc, uint32_t info)
+{
+}
+
+int main()
+{
+    es_adv_timers_init();
+    es_adv_frame_fill_connectable_adv_data(NULL, NULL);
+    es_adv_timing_resolve(NULL);
+    es_adv_timing_init(NULL);
+    es_battery_voltage_get(NULL);
+    es_flash_init();
+    es_gatts_read_handle_unlock(NULL);
+    es_gatts_write_handle_unlock(NULL, NULL, 0, 0);
+    es_gatts_init(NULL);
+    es_security_init(NULL);
+    es_slot_reg_init(NULL);
+    es_slots_init(NULL);
+    es_stopwatch_init();
+    es_tlm_init();
+    nrf_ble_es_init(NULL);
+    return 0;
+}

--- a/ci/libraries_tests/nrf5_ble_srv_eddystone/sdk_config.h
+++ b/ci/libraries_tests/nrf5_ble_srv_eddystone/sdk_config.h
@@ -1,0 +1,1665 @@
+#ifndef SDK_CONFIG_H
+#define SDK_CONFIG_H
+
+#ifndef NRF_LOG_ENABLED
+#define NRF_LOG_ENABLED 0
+#endif
+
+// </h>
+//==========================================================
+
+// </h>
+//==========================================================
+
+// <h> nRF_SoftDevice
+
+//==========================================================
+// <e> NRF_SDH_BLE_ENABLED - nrf_sdh_ble - SoftDevice BLE event handler
+//==========================================================
+#ifndef NRF_SDH_BLE_ENABLED
+#define NRF_SDH_BLE_ENABLED 1
+#endif
+// <h> BLE Stack configuration - Stack configuration parameters
+
+// <i> The SoftDevice handler will configure the stack with these parameters when calling @ref nrf_sdh_ble_default_cfg_set.
+// <i> Other libraries might depend on these values; keep them up-to-date even if you are not explicitely calling @ref nrf_sdh_ble_default_cfg_set.
+//==========================================================
+// <o> NRF_SDH_BLE_GAP_DATA_LENGTH   <27-251>
+
+// <i> Requested BLE GAP data length to be negotiated.
+
+#ifndef NRF_SDH_BLE_GAP_DATA_LENGTH
+#define NRF_SDH_BLE_GAP_DATA_LENGTH 27
+#endif
+
+// <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links.
+#ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links.
+#ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count.
+// <i> Maximum number of total concurrent connections using the default configuration.
+
+#ifndef NRF_SDH_BLE_TOTAL_LINK_COUNT
+#define NRF_SDH_BLE_TOTAL_LINK_COUNT 1
+#endif
+
+// <o> NRF_SDH_BLE_GAP_EVENT_LENGTH - GAP event length.
+// <i> The time set aside for this connection on every connection interval in 1.25 ms units.
+
+#ifndef NRF_SDH_BLE_GAP_EVENT_LENGTH
+#define NRF_SDH_BLE_GAP_EVENT_LENGTH 6
+#endif
+
+// <o> NRF_SDH_BLE_GATT_MAX_MTU_SIZE - Static maximum MTU size.
+#ifndef NRF_SDH_BLE_GATT_MAX_MTU_SIZE
+#define NRF_SDH_BLE_GATT_MAX_MTU_SIZE 23
+#endif
+
+// <o> NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE - Attribute Table size in bytes. The size must be a multiple of 4.
+#ifndef NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE
+#define NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE 1408
+#endif
+
+// <o> NRF_SDH_BLE_VS_UUID_COUNT - The number of vendor-specific UUIDs.
+#ifndef NRF_SDH_BLE_VS_UUID_COUNT
+#define NRF_SDH_BLE_VS_UUID_COUNT 0
+#endif
+
+// <q> NRF_SDH_BLE_SERVICE_CHANGED  - Include the Service Changed characteristic in the Attribute Table.
+
+#ifndef NRF_SDH_BLE_SERVICE_CHANGED
+#define NRF_SDH_BLE_SERVICE_CHANGED 0
+#endif
+
+// <e> NRF_SDH_SOC_ENABLED - nrf_sdh_soc - SoftDevice SoC event handler
+//==========================================================
+#ifndef NRF_SDH_SOC_ENABLED
+#define NRF_SDH_SOC_ENABLED 1
+#endif
+// <h> SoC Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_SOC_OBSERVER_PRIO_LEVELS - Total number of priority levels for SoC observers.
+// <i> This setting configures the number of priority levels available for the SoC event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_SOC_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_SOC_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <h> SoC Observers priorities - Invididual priorities
+
+// <e> NRF_SDH_ENABLED - nrf_sdh - SoftDevice handler
+//==========================================================
+#ifndef NRF_SDH_ENABLED
+#define NRF_SDH_ENABLED 1
+#endif
+
+// </h>
+//==========================================================
+
+// <h> Clock - SoftDevice clock configuration
+
+//==========================================================
+// <o> NRF_SDH_CLOCK_LF_SRC  - SoftDevice clock source.
+
+// <0=> NRF_CLOCK_LF_SRC_RC
+// <1=> NRF_CLOCK_LF_SRC_XTAL
+// <2=> NRF_CLOCK_LF_SRC_SYNTH
+
+#ifndef NRF_SDH_CLOCK_LF_SRC
+#define NRF_SDH_CLOCK_LF_SRC 1
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_CTIV - SoftDevice calibration timer interval.
+#ifndef NRF_SDH_CLOCK_LF_RC_CTIV
+#define NRF_SDH_CLOCK_LF_RC_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_TEMP_CTIV - SoftDevice calibration timer interval under constant temperature.
+// <i> How often (in number of calibration intervals) the RC oscillator shall be calibrated
+// <i>  if the temperature has not changed.
+
+#ifndef NRF_SDH_CLOCK_LF_RC_TEMP_CTIV
+#define NRF_SDH_CLOCK_LF_RC_TEMP_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_ACCURACY  - External clock accuracy used in the LL to compute timing.
+
+// <0=> NRF_CLOCK_LF_ACCURACY_250_PPM
+// <1=> NRF_CLOCK_LF_ACCURACY_500_PPM
+// <2=> NRF_CLOCK_LF_ACCURACY_150_PPM
+// <3=> NRF_CLOCK_LF_ACCURACY_100_PPM
+// <4=> NRF_CLOCK_LF_ACCURACY_75_PPM
+// <5=> NRF_CLOCK_LF_ACCURACY_50_PPM
+// <6=> NRF_CLOCK_LF_ACCURACY_30_PPM
+// <7=> NRF_CLOCK_LF_ACCURACY_20_PPM
+// <8=> NRF_CLOCK_LF_ACCURACY_10_PPM
+// <9=> NRF_CLOCK_LF_ACCURACY_5_PPM
+// <10=> NRF_CLOCK_LF_ACCURACY_2_PPM
+// <11=> NRF_CLOCK_LF_ACCURACY_1_PPM
+
+#ifndef NRF_SDH_CLOCK_LF_ACCURACY
+#define NRF_SDH_CLOCK_LF_ACCURACY 7
+#endif
+
+// <o> NRF_SDH_SOC_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which SoC events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have SoC events dispatched before or after other stack events, such as ANT or BLE.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_SOC_STACK_OBSERVER_PRIO
+#define NRF_SDH_SOC_STACK_OBSERVER_PRIO 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> BLE Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_BLE_OBSERVER_PRIO_LEVELS - Total number of priority levels for BLE observers.
+// <i> This setting configures the number of priority levels available for BLE event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_BLE_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_BLE_OBSERVER_PRIO_LEVELS 4
+#endif
+
+// <h> BLE Observers priorities - Invididual priorities
+
+//==========================================================
+// <o> BLE_ADV_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Advertising module.
+
+#ifndef BLE_ADV_BLE_OBSERVER_PRIO
+#define BLE_ADV_BLE_OBSERVER_PRIO 1
+#endif
+
+// <o> BLE_CONN_STATE_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Connection State module.
+
+#ifndef BLE_CONN_STATE_BLE_OBSERVER_PRIO
+#define BLE_CONN_STATE_BLE_OBSERVER_PRIO 0
+#endif
+
+// <o> NRF_SDH_STACK_OBSERVER_PRIO_LEVELS - Total number of priority levels for stack event observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice stack event handlers (ANT, BLE, SoC).
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STACK_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_BLE_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which BLE events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have BLE events dispatched before or after other stack events, such as ANT or SoC.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_BLE_STACK_OBSERVER_PRIO
+#define NRF_SDH_BLE_STACK_OBSERVER_PRIO 0
+#endif
+
+//---
+
+// <e> NRF_BLE_QWR_ENABLED - nrf_ble_qwr - Queued writes support module (prepare/execute write)
+//==========================================================
+#ifndef NRF_BLE_QWR_ENABLED
+#define NRF_BLE_QWR_ENABLED 1
+#endif
+// <o> NRF_BLE_QWR_MAX_ATTR - Maximum number of attribute handles that can be registered. This number must be adjusted according to the number of attributes for which Queued Writes will be enabled. If it is zero, the module will reject all Queued Write requests.
+#ifndef NRF_BLE_QWR_MAX_ATTR
+#define NRF_BLE_QWR_MAX_ATTR 1
+#endif
+
+// <q> NRF_SECTION_ITER_ENABLED  - nrf_section_iter - Section iterator
+
+#ifndef NRF_SECTION_ITER_ENABLED
+#define NRF_SECTION_ITER_ENABLED 1
+#endif
+
+// <e> SAADC_ENABLED - nrf_drv_saadc - SAADC peripheral driver - legacy layer
+//==========================================================
+#ifndef SAADC_ENABLED
+#define SAADC_ENABLED 1
+#endif
+// <o> SAADC_CONFIG_RESOLUTION  - Resolution
+
+// <0=> 8 bit
+// <1=> 10 bit
+// <2=> 12 bit
+// <3=> 14 bit
+
+#ifndef SAADC_CONFIG_RESOLUTION
+#define SAADC_CONFIG_RESOLUTION 1
+#endif
+
+// <o> SAADC_CONFIG_OVERSAMPLE  - Sample period
+
+// <0=> Disabled
+// <1=> 2x
+// <2=> 4x
+// <3=> 8x
+// <4=> 16x
+// <5=> 32x
+// <6=> 64x
+// <7=> 128x
+// <8=> 256x
+
+#ifndef SAADC_CONFIG_OVERSAMPLE
+#define SAADC_CONFIG_OVERSAMPLE 0
+#endif
+
+// <q> SAADC_CONFIG_LP_MODE  - Enabling low power mode
+
+#ifndef SAADC_CONFIG_LP_MODE
+#define SAADC_CONFIG_LP_MODE 0
+#endif
+
+// <o> SAADC_CONFIG_IRQ_PRIORITY  - Interrupt priority
+
+// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef SAADC_CONFIG_IRQ_PRIORITY
+#define SAADC_CONFIG_IRQ_PRIORITY 6
+#endif
+
+// </e>
+
+// <e> NRFX_SAADC_ENABLED - nrfx_saadc - SAADC peripheral driver
+//==========================================================
+#ifndef NRFX_SAADC_ENABLED
+#define NRFX_SAADC_ENABLED 1
+#endif
+// <o> NRFX_SAADC_CONFIG_RESOLUTION  - Resolution
+
+// <0=> 8 bit
+// <1=> 10 bit
+// <2=> 12 bit
+// <3=> 14 bit
+
+#ifndef NRFX_SAADC_CONFIG_RESOLUTION
+#define NRFX_SAADC_CONFIG_RESOLUTION 1
+#endif
+
+// <o> NRFX_SAADC_CONFIG_OVERSAMPLE  - Sample period
+
+// <0=> Disabled
+// <1=> 2x
+// <2=> 4x
+// <3=> 8x
+// <4=> 16x
+// <5=> 32x
+// <6=> 64x
+// <7=> 128x
+// <8=> 256x
+
+#ifndef NRFX_SAADC_CONFIG_OVERSAMPLE
+#define NRFX_SAADC_CONFIG_OVERSAMPLE 0
+#endif
+
+// <q> NRFX_SAADC_CONFIG_LP_MODE  - Enabling low power mode
+
+#ifndef NRFX_SAADC_CONFIG_LP_MODE
+#define NRFX_SAADC_CONFIG_LP_MODE 0
+#endif
+
+// <o> NRFX_SAADC_CONFIG_IRQ_PRIORITY  - Interrupt priority
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_SAADC_CONFIG_IRQ_PRIORITY
+#define NRFX_SAADC_CONFIG_IRQ_PRIORITY 6
+#endif
+
+// <e> NRFX_SAADC_CONFIG_LOG_ENABLED - Enables logging in the module.
+//==========================================================
+#ifndef NRFX_SAADC_CONFIG_LOG_ENABLED
+#define NRFX_SAADC_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_SAADC_CONFIG_LOG_LEVEL  - Default Severity level
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_SAADC_CONFIG_LOG_LEVEL
+#define NRFX_SAADC_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_SAADC_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_SAADC_CONFIG_INFO_COLOR
+#define NRFX_SAADC_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_SAADC_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_SAADC_CONFIG_DEBUG_COLOR
+#define NRFX_SAADC_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
+// <e> APP_TIMER_ENABLED - app_timer - Application timer functionality
+//==========================================================
+#ifndef APP_TIMER_ENABLED
+#define APP_TIMER_ENABLED 1
+#endif
+// <o> APP_TIMER_CONFIG_RTC_FREQUENCY  - Configure RTC prescaler.
+
+// <0=> 32768 Hz
+// <1=> 16384 Hz
+// <3=> 8192 Hz
+// <7=> 4096 Hz
+// <15=> 2048 Hz
+// <31=> 1024 Hz
+
+#ifndef APP_TIMER_CONFIG_RTC_FREQUENCY
+#define APP_TIMER_CONFIG_RTC_FREQUENCY 1
+#endif
+
+// <o> APP_TIMER_CONFIG_IRQ_PRIORITY  - Interrupt priority
+
+// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef APP_TIMER_CONFIG_IRQ_PRIORITY
+#define APP_TIMER_CONFIG_IRQ_PRIORITY 6
+#endif
+
+// <o> APP_TIMER_CONFIG_OP_QUEUE_SIZE - Capacity of timer requests queue.
+// <i> Size of the queue depends on how many timers are used
+// <i> in the system, how often timers are started and overall
+// <i> system latency. If queue size is too small app_timer calls
+// <i> will fail.
+
+#ifndef APP_TIMER_CONFIG_OP_QUEUE_SIZE
+#define APP_TIMER_CONFIG_OP_QUEUE_SIZE 10
+#endif
+
+// <q> APP_TIMER_CONFIG_USE_SCHEDULER  - Enable scheduling app_timer events to app_scheduler
+
+#ifndef APP_TIMER_CONFIG_USE_SCHEDULER
+#define APP_TIMER_CONFIG_USE_SCHEDULER 0
+#endif
+
+// <q> APP_TIMER_KEEPS_RTC_ACTIVE  - Enable RTC always on
+
+// <i> If option is enabled RTC is kept running even if there is no active timers.
+// <i> This option can be used when app_timer is used for timestamping.
+
+#ifndef APP_TIMER_KEEPS_RTC_ACTIVE
+#define APP_TIMER_KEEPS_RTC_ACTIVE 0
+#endif
+
+// <o> APP_TIMER_SAFE_WINDOW_MS - Maximum possible latency (in milliseconds) of handling app_timer event.
+// <i> Maximum possible timeout that can be set is reduced by safe window.
+// <i> Example: RTC frequency 16384 Hz, maximum possible timeout 1024 seconds - APP_TIMER_SAFE_WINDOW_MS.
+// <i> Since RTC is not stopped when processor is halted in debugging session, this value
+// <i> must cover it if debugging is needed. It is possible to halt processor for APP_TIMER_SAFE_WINDOW_MS
+// <i> without corrupting app_timer behavior.
+
+#ifndef APP_TIMER_SAFE_WINDOW_MS
+#define APP_TIMER_SAFE_WINDOW_MS 300000
+#endif
+
+// <h> App Timer Legacy configuration - Legacy configuration.
+
+//==========================================================
+// <q> APP_TIMER_WITH_PROFILER  - Enable app_timer profiling
+
+#ifndef APP_TIMER_WITH_PROFILER
+#define APP_TIMER_WITH_PROFILER 0
+#endif
+
+// <q> APP_TIMER_CONFIG_SWI_NUMBER  - Configure SWI instance used.
+
+#ifndef APP_TIMER_CONFIG_SWI_NUMBER
+#define APP_TIMER_CONFIG_SWI_NUMBER 0
+#endif
+
+#ifndef NRF_BLE_ES_BLE_OBSERVER_PRIO
+#define NRF_BLE_ES_BLE_OBSERVER_PRIO 2
+#endif
+
+// </h>
+//==========================================================
+
+// <h> nRF_Crypto
+
+//==========================================================
+// <e> NRF_CRYPTO_ENABLED - nrf_crypto - Cryptography library.
+//==========================================================
+#ifndef NRF_CRYPTO_ENABLED
+#define NRF_CRYPTO_ENABLED 1
+#endif
+
+#ifndef NRF_CRYPTO_AEAD_ENABLED
+#define NRF_CRYPTO_AEAD_ENABLED 1
+#endif
+
+#ifndef NRF_CRYPTO_AES_ENABLED
+#define NRF_CRYPTO_AES_ENABLED 1
+#endif
+
+#ifndef NRF_CRYPTO_HASH_ENABLED
+#define NRF_CRYPTO_HASH_ENABLED 1
+#endif
+
+#ifndef NRF_CRYPTO_HMAC_ENABLED
+#define NRF_CRYPTO_HMAC_ENABLED 1
+#endif
+
+// <o> NRF_CRYPTO_ALLOCATOR  - Memory allocator
+
+// <i> Choose memory allocator used by nrf_crypto. Default is alloca if possible or nrf_malloc otherwise. If 'User macros' are selected, the user has to create 'nrf_crypto_allocator.h' file that contains NRF_CRYPTO_ALLOC, NRF_CRYPTO_FREE, and NRF_CRYPTO_ALLOC_ON_STACK.
+// <0=> Default
+// <1=> User macros
+// <2=> On stack (alloca)
+// <3=> C dynamic memory (malloc)
+// <4=> SDK Memory Manager (nrf_malloc)
+
+#ifndef NRF_CRYPTO_ALLOCATOR
+#define NRF_CRYPTO_ALLOCATOR 0
+#endif
+
+// <e> NRF_CRYPTO_BACKEND_CC310_BL_ENABLED - Enable the ARM Cryptocell CC310 reduced backend.
+
+// <i> The CC310 hardware-accelerated cryptography backend with reduced functionality and footprint (only available on nRF52840).
+//==========================================================
+#ifndef NRF_CRYPTO_BACKEND_CC310_BL_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_BL_ENABLED 0
+#endif
+// <q> NRF_CRYPTO_BACKEND_CC310_BL_ECC_SECP224R1_ENABLED  - Enable the secp224r1 elliptic curve support using CC310_BL.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_BL_ECC_SECP224R1_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_BL_ECC_SECP224R1_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_BL_ECC_SECP256R1_ENABLED  - Enable the secp256r1 elliptic curve support using CC310_BL.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_BL_ECC_SECP256R1_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_BL_ECC_SECP256R1_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_BL_HASH_SHA256_ENABLED  - CC310_BL SHA-256 hash functionality.
+
+// <i> CC310_BL backend implementation for hardware-accelerated SHA-256.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_BL_HASH_SHA256_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_BL_HASH_SHA256_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_BL_HASH_AUTOMATIC_RAM_BUFFER_ENABLED  - nrf_cc310_bl buffers to RAM before running hash operation
+
+// <i> Enabling this makes hashing of addresses in FLASH range possible. Size of buffer allocated for hashing is set by NRF_CRYPTO_BACKEND_CC310_BL_HASH_AUTOMATIC_RAM_BUFFER_SIZE
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_BL_HASH_AUTOMATIC_RAM_BUFFER_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_BL_HASH_AUTOMATIC_RAM_BUFFER_ENABLED 0
+#endif
+
+// <o> NRF_CRYPTO_BACKEND_CC310_BL_HASH_AUTOMATIC_RAM_BUFFER_SIZE - nrf_cc310_bl hash outputs digests in little endian
+// <i> Makes the nrf_cc310_bl hash functions output digests in little endian format. Only for use in nRF SDK DFU!
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_BL_HASH_AUTOMATIC_RAM_BUFFER_SIZE
+#define NRF_CRYPTO_BACKEND_CC310_BL_HASH_AUTOMATIC_RAM_BUFFER_SIZE 4096
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_BL_INTERRUPTS_ENABLED  - Enable Interrupts while support using CC310 bl.
+
+// <i> Select a library version compatible with the configuration. When interrupts are disable, a version named _noint must be used
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_BL_INTERRUPTS_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_BL_INTERRUPTS_ENABLED 1
+#endif
+
+// </e>
+
+// <e> NRF_CRYPTO_BACKEND_CC310_ENABLED - Enable the ARM Cryptocell CC310 backend.
+
+// <i> The CC310 hardware-accelerated cryptography backend (only available on nRF52840).
+//==========================================================
+#ifndef NRF_CRYPTO_BACKEND_CC310_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_ENABLED 0
+#endif
+// <q> NRF_CRYPTO_BACKEND_CC310_AES_CBC_ENABLED  - Enable the AES CBC mode using CC310.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_AES_CBC_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_AES_CBC_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_AES_CTR_ENABLED  - Enable the AES CTR mode using CC310.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_AES_CTR_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_AES_CTR_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_AES_ECB_ENABLED  - Enable the AES ECB mode using CC310.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_AES_ECB_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_AES_ECB_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_AES_CBC_MAC_ENABLED  - Enable the AES CBC_MAC mode using CC310.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_AES_CBC_MAC_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_AES_CBC_MAC_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_AES_CMAC_ENABLED  - Enable the AES CMAC mode using CC310.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_AES_CMAC_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_AES_CMAC_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_AES_CCM_ENABLED  - Enable the AES CCM mode using CC310.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_AES_CCM_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_AES_CCM_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_AES_CCM_STAR_ENABLED  - Enable the AES CCM* mode using CC310.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_AES_CCM_STAR_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_AES_CCM_STAR_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_CHACHA_POLY_ENABLED  - Enable the CHACHA-POLY mode using CC310.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_CHACHA_POLY_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_CHACHA_POLY_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_ECC_SECP160R1_ENABLED  - Enable the secp160r1 elliptic curve support using CC310.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_ECC_SECP160R1_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_ECC_SECP160R1_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_ECC_SECP160R2_ENABLED  - Enable the secp160r2 elliptic curve support using CC310.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_ECC_SECP160R2_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_ECC_SECP160R2_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_ECC_SECP192R1_ENABLED  - Enable the secp192r1 elliptic curve support using CC310.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_ECC_SECP192R1_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_ECC_SECP192R1_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_ECC_SECP224R1_ENABLED  - Enable the secp224r1 elliptic curve support using CC310.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_ECC_SECP224R1_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_ECC_SECP224R1_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_ECC_SECP256R1_ENABLED  - Enable the secp256r1 elliptic curve support using CC310.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_ECC_SECP256R1_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_ECC_SECP256R1_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_ECC_SECP384R1_ENABLED  - Enable the secp384r1 elliptic curve support using CC310.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_ECC_SECP384R1_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_ECC_SECP384R1_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_ECC_SECP521R1_ENABLED  - Enable the secp521r1 elliptic curve support using CC310.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_ECC_SECP521R1_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_ECC_SECP521R1_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_ECC_SECP160K1_ENABLED  - Enable the secp160k1 elliptic curve support using CC310.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_ECC_SECP160K1_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_ECC_SECP160K1_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_ECC_SECP192K1_ENABLED  - Enable the secp192k1 elliptic curve support using CC310.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_ECC_SECP192K1_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_ECC_SECP192K1_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_ECC_SECP224K1_ENABLED  - Enable the secp224k1 elliptic curve support using CC310.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_ECC_SECP224K1_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_ECC_SECP224K1_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_ECC_SECP256K1_ENABLED  - Enable the secp256k1 elliptic curve support using CC310.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_ECC_SECP256K1_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_ECC_SECP256K1_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_ECC_CURVE25519_ENABLED  - Enable the Curve25519 curve support using CC310.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_ECC_CURVE25519_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_ECC_CURVE25519_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_ECC_ED25519_ENABLED  - Enable the Ed25519 curve support using CC310.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_ECC_ED25519_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_ECC_ED25519_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_HASH_SHA256_ENABLED  - CC310 SHA-256 hash functionality.
+
+// <i> CC310 backend implementation for hardware-accelerated SHA-256.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_HASH_SHA256_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_HASH_SHA256_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_HASH_SHA512_ENABLED  - CC310 SHA-512 hash functionality
+
+// <i> CC310 backend implementation for SHA-512 (in software).
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_HASH_SHA512_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_HASH_SHA512_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_HMAC_SHA256_ENABLED  - CC310 HMAC using SHA-256
+
+// <i> CC310 backend implementation for HMAC using hardware-accelerated SHA-256.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_HMAC_SHA256_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_HMAC_SHA256_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_HMAC_SHA512_ENABLED  - CC310 HMAC using SHA-512
+
+// <i> CC310 backend implementation for HMAC using SHA-512 (in software).
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_HMAC_SHA512_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_HMAC_SHA512_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_RNG_ENABLED  - Enable RNG support using CC310.
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_RNG_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_RNG_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_CC310_INTERRUPTS_ENABLED  - Enable Interrupts while support using CC310.
+
+// <i> Select a library version compatible with the configuration. When interrupts are disable, a version named _noint must be used
+
+#ifndef NRF_CRYPTO_BACKEND_CC310_INTERRUPTS_ENABLED
+#define NRF_CRYPTO_BACKEND_CC310_INTERRUPTS_ENABLED 1
+#endif
+
+// </e>
+
+// <e> NRF_CRYPTO_BACKEND_CIFRA_ENABLED - Enable the Cifra backend.
+//==========================================================
+#ifndef NRF_CRYPTO_BACKEND_CIFRA_ENABLED
+#define NRF_CRYPTO_BACKEND_CIFRA_ENABLED 1
+#endif
+// <q> NRF_CRYPTO_BACKEND_CIFRA_AES_EAX_ENABLED  - Enable the AES EAX mode using Cifra.
+
+#ifndef NRF_CRYPTO_BACKEND_CIFRA_AES_EAX_ENABLED
+#define NRF_CRYPTO_BACKEND_CIFRA_AES_EAX_ENABLED 1
+#endif
+
+// </e>
+
+// <e> NRF_CRYPTO_BACKEND_MBEDTLS_ENABLED - Enable the mbed TLS backend.
+//==========================================================
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_ENABLED 1
+#endif
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_AES_CBC_ENABLED  - Enable the AES CBC mode mbed TLS.
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_AES_CBC_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_AES_CBC_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_AES_CTR_ENABLED  - Enable the AES CTR mode using mbed TLS.
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_AES_CTR_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_AES_CTR_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_AES_CFB_ENABLED  - Enable the AES CFB mode using mbed TLS.
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_AES_CFB_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_AES_CFB_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_AES_ECB_ENABLED  - Enable the AES ECB mode using mbed TLS.
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_AES_ECB_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_AES_ECB_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_AES_CBC_MAC_ENABLED  - Enable the AES CBC MAC mode using mbed TLS.
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_AES_CBC_MAC_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_AES_CBC_MAC_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_AES_CMAC_ENABLED  - Enable the AES CMAC mode using mbed TLS.
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_AES_CMAC_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_AES_CMAC_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_AES_CCM_ENABLED  - Enable the AES CCM mode using mbed TLS.
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_AES_CCM_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_AES_CCM_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_AES_GCM_ENABLED  - Enable the AES GCM mode using mbed TLS.
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_AES_GCM_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_AES_GCM_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP192R1_ENABLED  - Enable secp192r1 (NIST 192-bit) curve
+
+// <i> Enable this setting if you need secp192r1 (NIST 192-bit) support using MBEDTLS
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP192R1_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP192R1_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP224R1_ENABLED  - Enable secp224r1 (NIST 224-bit) curve
+
+// <i> Enable this setting if you need secp224r1 (NIST 224-bit) support using MBEDTLS
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP224R1_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP224R1_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP256R1_ENABLED  - Enable secp256r1 (NIST 256-bit) curve
+
+// <i> Enable this setting if you need secp256r1 (NIST 256-bit) support using MBEDTLS
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP256R1_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP256R1_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP384R1_ENABLED  - Enable secp384r1 (NIST 384-bit) curve
+
+// <i> Enable this setting if you need secp384r1 (NIST 384-bit) support using MBEDTLS
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP384R1_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP384R1_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP521R1_ENABLED  - Enable secp521r1 (NIST 521-bit) curve
+
+// <i> Enable this setting if you need secp521r1 (NIST 521-bit) support using MBEDTLS
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP521R1_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP521R1_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP192K1_ENABLED  - Enable secp192k1 (Koblitz 192-bit) curve
+
+// <i> Enable this setting if you need secp192k1 (Koblitz 192-bit) support using MBEDTLS
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP192K1_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP192K1_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP224K1_ENABLED  - Enable secp224k1 (Koblitz 224-bit) curve
+
+// <i> Enable this setting if you need secp224k1 (Koblitz 224-bit) support using MBEDTLS
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP224K1_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP224K1_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP256K1_ENABLED  - Enable secp256k1 (Koblitz 256-bit) curve
+
+// <i> Enable this setting if you need secp256k1 (Koblitz 256-bit) support using MBEDTLS
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP256K1_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_ECC_SECP256K1_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_ECC_BP256R1_ENABLED  - Enable bp256r1 (Brainpool 256-bit) curve
+
+// <i> Enable this setting if you need bp256r1 (Brainpool 256-bit) support using MBEDTLS
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_ECC_BP256R1_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_ECC_BP256R1_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_ECC_BP384R1_ENABLED  - Enable bp384r1 (Brainpool 384-bit) curve
+
+// <i> Enable this setting if you need bp384r1 (Brainpool 384-bit) support using MBEDTLS
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_ECC_BP384R1_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_ECC_BP384R1_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_ECC_BP512R1_ENABLED  - Enable bp512r1 (Brainpool 512-bit) curve
+
+// <i> Enable this setting if you need bp512r1 (Brainpool 512-bit) support using MBEDTLS
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_ECC_BP512R1_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_ECC_BP512R1_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_ECC_CURVE25519_ENABLED  - Enable Curve25519 curve
+
+// <i> Enable this setting if you need Curve25519 support using MBEDTLS
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_ECC_CURVE25519_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_ECC_CURVE25519_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_HASH_SHA256_ENABLED  - Enable mbed TLS SHA-256 hash functionality.
+
+// <i> mbed TLS backend implementation for SHA-256.
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_HASH_SHA256_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_HASH_SHA256_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_HASH_SHA512_ENABLED  - Enable mbed TLS SHA-512 hash functionality.
+
+// <i> mbed TLS backend implementation for SHA-512.
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_HASH_SHA512_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_HASH_SHA512_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_HMAC_SHA256_ENABLED  - Enable mbed TLS HMAC using SHA-256.
+
+// <i> mbed TLS backend implementation for HMAC using SHA-256.
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_HMAC_SHA256_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_HMAC_SHA256_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MBEDTLS_HMAC_SHA512_ENABLED  - Enable mbed TLS HMAC using SHA-512.
+
+// <i> mbed TLS backend implementation for HMAC using SHA-512.
+
+#ifndef NRF_CRYPTO_BACKEND_MBEDTLS_HMAC_SHA512_ENABLED
+#define NRF_CRYPTO_BACKEND_MBEDTLS_HMAC_SHA512_ENABLED 0
+#endif
+
+// </e>
+
+// <e> NRF_CRYPTO_BACKEND_MICRO_ECC_ENABLED - Enable the micro-ecc backend.
+//==========================================================
+#ifndef NRF_CRYPTO_BACKEND_MICRO_ECC_ENABLED
+#define NRF_CRYPTO_BACKEND_MICRO_ECC_ENABLED 0
+#endif
+// <q> NRF_CRYPTO_BACKEND_MICRO_ECC_ECC_SECP192R1_ENABLED  - Enable secp192r1 (NIST 192-bit) curve
+
+// <i> Enable this setting if you need secp192r1 (NIST 192-bit) support using micro-ecc
+
+#ifndef NRF_CRYPTO_BACKEND_MICRO_ECC_ECC_SECP192R1_ENABLED
+#define NRF_CRYPTO_BACKEND_MICRO_ECC_ECC_SECP192R1_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MICRO_ECC_ECC_SECP224R1_ENABLED  - Enable secp224r1 (NIST 224-bit) curve
+
+// <i> Enable this setting if you need secp224r1 (NIST 224-bit) support using micro-ecc
+
+#ifndef NRF_CRYPTO_BACKEND_MICRO_ECC_ECC_SECP224R1_ENABLED
+#define NRF_CRYPTO_BACKEND_MICRO_ECC_ECC_SECP224R1_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MICRO_ECC_ECC_SECP256R1_ENABLED  - Enable secp256r1 (NIST 256-bit) curve
+
+// <i> Enable this setting if you need secp256r1 (NIST 256-bit) support using micro-ecc
+
+#ifndef NRF_CRYPTO_BACKEND_MICRO_ECC_ECC_SECP256R1_ENABLED
+#define NRF_CRYPTO_BACKEND_MICRO_ECC_ECC_SECP256R1_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_MICRO_ECC_ECC_SECP256K1_ENABLED  - Enable secp256k1 (Koblitz 256-bit) curve
+
+// <i> Enable this setting if you need secp256k1 (Koblitz 256-bit) support using micro-ecc
+
+#ifndef NRF_CRYPTO_BACKEND_MICRO_ECC_ECC_SECP256K1_ENABLED
+#define NRF_CRYPTO_BACKEND_MICRO_ECC_ECC_SECP256K1_ENABLED 1
+#endif
+
+// </e>
+
+// <e> NRF_CRYPTO_BACKEND_NRF_HW_RNG_ENABLED - Enable the nRF HW RNG backend.
+
+// <i> The nRF HW backend provide access to RNG peripheral in nRF5x devices.
+//==========================================================
+#ifndef NRF_CRYPTO_BACKEND_NRF_HW_RNG_ENABLED
+#define NRF_CRYPTO_BACKEND_NRF_HW_RNG_ENABLED 1
+#endif
+// <q> NRF_CRYPTO_BACKEND_NRF_HW_RNG_MBEDTLS_CTR_DRBG_ENABLED  - Enable mbed TLS CTR-DRBG algorithm.
+
+// <i> Enable mbed TLS CTR-DRBG standardized by NIST (NIST SP 800-90A Rev. 1). The nRF HW RNG is used as an entropy source for seeding.
+
+#ifndef NRF_CRYPTO_BACKEND_NRF_HW_RNG_MBEDTLS_CTR_DRBG_ENABLED
+#define NRF_CRYPTO_BACKEND_NRF_HW_RNG_MBEDTLS_CTR_DRBG_ENABLED 0
+#endif
+
+// </e>
+
+// <e> NRF_CRYPTO_BACKEND_NRF_SW_ENABLED - Enable the legacy nRFx sw for crypto.
+
+// <i> The nRF SW cryptography backend (only used in bootloader context).
+//==========================================================
+#ifndef NRF_CRYPTO_BACKEND_NRF_SW_ENABLED
+#define NRF_CRYPTO_BACKEND_NRF_SW_ENABLED 0
+#endif
+// <q> NRF_CRYPTO_BACKEND_NRF_SW_HASH_SHA256_ENABLED  - nRF SW hash backend support for SHA-256
+
+// <i> The nRF SW backend provide access to nRF SDK legacy hash implementation of SHA-256.
+
+#ifndef NRF_CRYPTO_BACKEND_NRF_SW_HASH_SHA256_ENABLED
+#define NRF_CRYPTO_BACKEND_NRF_SW_HASH_SHA256_ENABLED 1
+#endif
+
+// <e> NRF_CRYPTO_BACKEND_OBERON_ENABLED - Enable the Oberon backend
+
+// <i> The Oberon backend
+//==========================================================
+#ifndef NRF_CRYPTO_BACKEND_OBERON_ENABLED
+#define NRF_CRYPTO_BACKEND_OBERON_ENABLED 1
+#endif
+// <q> NRF_CRYPTO_BACKEND_OBERON_CHACHA_POLY_ENABLED  - Enable the CHACHA-POLY mode using Oberon.
+
+#ifndef NRF_CRYPTO_BACKEND_OBERON_CHACHA_POLY_ENABLED
+#define NRF_CRYPTO_BACKEND_OBERON_CHACHA_POLY_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_OBERON_ECC_SECP256R1_ENABLED  - Enable secp256r1 curve
+
+// <i> Enable this setting if you need secp256r1 curve support using Oberon library
+
+#ifndef NRF_CRYPTO_BACKEND_OBERON_ECC_SECP256R1_ENABLED
+#define NRF_CRYPTO_BACKEND_OBERON_ECC_SECP256R1_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_OBERON_ECC_CURVE25519_ENABLED  - Enable Curve25519 ECDH
+
+// <i> Enable this setting if you need Curve25519 ECDH support using Oberon library
+
+#ifndef NRF_CRYPTO_BACKEND_OBERON_ECC_CURVE25519_ENABLED
+#define NRF_CRYPTO_BACKEND_OBERON_ECC_CURVE25519_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_OBERON_ECC_ED25519_ENABLED  - Enable Ed25519 signature scheme
+
+// <i> Enable this setting if you need Ed25519 support using Oberon library
+
+#ifndef NRF_CRYPTO_BACKEND_OBERON_ECC_ED25519_ENABLED
+#define NRF_CRYPTO_BACKEND_OBERON_ECC_ED25519_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_OBERON_HASH_SHA256_ENABLED  - Oberon SHA-256 hash functionality
+
+// <i> Oberon backend implementation for SHA-256.
+
+#ifndef NRF_CRYPTO_BACKEND_OBERON_HASH_SHA256_ENABLED
+#define NRF_CRYPTO_BACKEND_OBERON_HASH_SHA256_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_OBERON_HASH_SHA512_ENABLED  - Oberon SHA-512 hash functionality
+
+// <i> Oberon backend implementation for SHA-512.
+
+#ifndef NRF_CRYPTO_BACKEND_OBERON_HASH_SHA512_ENABLED
+#define NRF_CRYPTO_BACKEND_OBERON_HASH_SHA512_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_OBERON_HMAC_SHA256_ENABLED  - Oberon HMAC using SHA-256
+
+// <i> Oberon backend implementation for HMAC using SHA-256.
+
+#ifndef NRF_CRYPTO_BACKEND_OBERON_HMAC_SHA256_ENABLED
+#define NRF_CRYPTO_BACKEND_OBERON_HMAC_SHA256_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_OBERON_HMAC_SHA512_ENABLED  - Oberon HMAC using SHA-512
+
+// <i> Oberon backend implementation for HMAC using SHA-512.
+
+#ifndef NRF_CRYPTO_BACKEND_OBERON_HMAC_SHA512_ENABLED
+#define NRF_CRYPTO_BACKEND_OBERON_HMAC_SHA512_ENABLED 0
+#endif
+
+// </e>
+
+// <e> NRF_CRYPTO_BACKEND_OPTIGA_ENABLED - Enable the nrf_crypto Optiga Trust X backend.
+
+// <i> Enables the nrf_crypto backend for Optiga Trust X devices.
+//==========================================================
+#ifndef NRF_CRYPTO_BACKEND_OPTIGA_ENABLED
+#define NRF_CRYPTO_BACKEND_OPTIGA_ENABLED 0
+#endif
+// <q> NRF_CRYPTO_BACKEND_OPTIGA_RNG_ENABLED  - Optiga backend support for RNG
+
+// <i> The Optiga backend provide external chip RNG.
+
+#ifndef NRF_CRYPTO_BACKEND_OPTIGA_RNG_ENABLED
+#define NRF_CRYPTO_BACKEND_OPTIGA_RNG_ENABLED 0
+#endif
+
+// <q> NRF_CRYPTO_BACKEND_OPTIGA_ECC_SECP256R1_ENABLED  - Optiga backend support for ECC secp256r1
+
+// <i> The Optiga backend provide external chip ECC using secp256r1.
+
+#ifndef NRF_CRYPTO_BACKEND_OPTIGA_ECC_SECP256R1_ENABLED
+#define NRF_CRYPTO_BACKEND_OPTIGA_ECC_SECP256R1_ENABLED 1
+#endif
+
+// </e>
+
+// <q> NRF_CRYPTO_CURVE25519_BIG_ENDIAN_ENABLED  - Big-endian byte order in raw Curve25519 data
+
+// <i> Enable big-endian byte order in Curve25519 API, if set to 1. Use little-endian, if set to 0.
+
+#ifndef NRF_CRYPTO_CURVE25519_BIG_ENDIAN_ENABLED
+#define NRF_CRYPTO_CURVE25519_BIG_ENDIAN_ENABLED 0
+#endif
+
+// </e>
+
+// <h> nrf_crypto_rng - RNG Configuration
+
+//==========================================================
+// <q> NRF_CRYPTO_RNG_STATIC_MEMORY_BUFFERS_ENABLED  - Use static memory buffers for context and temporary init buffer.
+
+// <i> Always recommended when using the nRF HW RNG as the context and temporary buffers are small. Consider disabling if using the CC310 RNG in a RAM constrained application. In this case, memory must be provided to nrf_crypto_rng_init, or it can be allocated internally provided that NRF_CRYPTO_ALLOCATOR does not allocate memory on the stack.
+
+#ifndef NRF_CRYPTO_RNG_STATIC_MEMORY_BUFFERS_ENABLED
+#define NRF_CRYPTO_RNG_STATIC_MEMORY_BUFFERS_ENABLED 1
+#endif
+
+// <q> NRF_CRYPTO_RNG_AUTO_INIT_ENABLED  - Initialize the RNG module automatically when nrf_crypto is initialized.
+
+// <i> Automatic initialization is only supported with static or internally allocated context and temporary memory.
+
+#ifndef NRF_CRYPTO_RNG_AUTO_INIT_ENABLED
+#define NRF_CRYPTO_RNG_AUTO_INIT_ENABLED 1
+#endif
+
+// <e> RNG_ENABLED - nrf_drv_rng - RNG peripheral driver - legacy layer
+//==========================================================
+#ifndef RNG_ENABLED
+#define RNG_ENABLED 1
+#endif
+// <q> RNG_CONFIG_ERROR_CORRECTION  - Error correction
+
+#ifndef RNG_CONFIG_ERROR_CORRECTION
+#define RNG_CONFIG_ERROR_CORRECTION 1
+#endif
+
+// <o> RNG_CONFIG_POOL_SIZE - Pool size
+#ifndef RNG_CONFIG_POOL_SIZE
+#define RNG_CONFIG_POOL_SIZE 64
+#endif
+
+// <o> RNG_CONFIG_IRQ_PRIORITY  - Interrupt priority
+
+// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef RNG_CONFIG_IRQ_PRIORITY
+#define RNG_CONFIG_IRQ_PRIORITY 6
+#endif
+
+// <o> RNG_CONFIG_STATE_OBSERVER_PRIO
+// <i> Priority with which state events are dispatched to this module.
+
+#ifndef RNG_CONFIG_STATE_OBSERVER_PRIO
+#define RNG_CONFIG_STATE_OBSERVER_PRIO 0
+#endif
+
+#ifndef NRF_SDH_STATE_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STATE_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <e> NRFX_RNG_ENABLED - nrfx_rng - RNG peripheral driver
+//==========================================================
+#ifndef NRFX_RNG_ENABLED
+#define NRFX_RNG_ENABLED 1
+#endif
+// <q> NRFX_RNG_CONFIG_ERROR_CORRECTION  - Error correction
+
+#ifndef NRFX_RNG_CONFIG_ERROR_CORRECTION
+#define NRFX_RNG_CONFIG_ERROR_CORRECTION 1
+#endif
+
+// <o> NRFX_RNG_CONFIG_IRQ_PRIORITY  - Interrupt priority
+
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef NRFX_RNG_CONFIG_IRQ_PRIORITY
+#define NRFX_RNG_CONFIG_IRQ_PRIORITY 6
+#endif
+
+// <e> NRFX_RNG_CONFIG_LOG_ENABLED - Enables logging in the module.
+//==========================================================
+#ifndef NRFX_RNG_CONFIG_LOG_ENABLED
+#define NRFX_RNG_CONFIG_LOG_ENABLED 0
+#endif
+// <o> NRFX_RNG_CONFIG_LOG_LEVEL  - Default Severity level
+
+// <0=> Off
+// <1=> Error
+// <2=> Warning
+// <3=> Info
+// <4=> Debug
+
+#ifndef NRFX_RNG_CONFIG_LOG_LEVEL
+#define NRFX_RNG_CONFIG_LOG_LEVEL 3
+#endif
+
+// <o> NRFX_RNG_CONFIG_INFO_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_RNG_CONFIG_INFO_COLOR
+#define NRFX_RNG_CONFIG_INFO_COLOR 0
+#endif
+
+// <o> NRFX_RNG_CONFIG_DEBUG_COLOR  - ANSI escape code prefix.
+
+// <0=> Default
+// <1=> Black
+// <2=> Red
+// <3=> Green
+// <4=> Yellow
+// <5=> Blue
+// <6=> Magenta
+// <7=> Cyan
+// <8=> White
+
+#ifndef NRFX_RNG_CONFIG_DEBUG_COLOR
+#define NRFX_RNG_CONFIG_DEBUG_COLOR 0
+#endif
+
+// </e>
+
+// </e>
+
+#ifndef NRF_QUEUE_ENABLED
+#define NRF_QUEUE_ENABLED 1
+#endif
+
+// <e> FDS_ENABLED - fds - Flash data storage module
+//==========================================================
+#ifndef FDS_ENABLED
+#define FDS_ENABLED 1
+#endif
+
+// <h> Pages - Virtual page settings
+
+// <i> Configure the number of virtual pages to use and their size.
+//==========================================================
+// <o> FDS_VIRTUAL_PAGES - Number of virtual flash pages to use.
+// <i> One of the virtual pages is reserved by the system for garbage collection.
+// <i> Therefore, the minimum is two virtual pages: one page to store data and one page to be used by the system for garbage collection.
+// <i> The total amount of flash memory that is used by FDS amounts to @ref FDS_VIRTUAL_PAGES * @ref FDS_VIRTUAL_PAGE_SIZE * 4 bytes.
+
+#ifndef FDS_VIRTUAL_PAGES
+#define FDS_VIRTUAL_PAGES 3
+#endif
+
+// <o> FDS_VIRTUAL_PAGE_SIZE  - The size of a virtual flash page.
+
+// <i> Expressed in number of 4-byte words.
+// <i> By default, a virtual page is the same size as a physical page.
+// <i> The size of a virtual page must be a multiple of the size of a physical page.
+// <1024=> 1024
+// <2048=> 2048
+
+#ifndef FDS_VIRTUAL_PAGE_SIZE
+#define FDS_VIRTUAL_PAGE_SIZE 1024
+#endif
+
+// <o> FDS_VIRTUAL_PAGES_RESERVED - The number of virtual flash pages that are used by other modules.
+// <i> FDS module stores its data in the last pages of the flash memory.
+// <i> By setting this value, you can move flash end address used by the FDS.
+// <i> As a result the reserved space can be used by other modules.
+
+#ifndef FDS_VIRTUAL_PAGES_RESERVED
+#define FDS_VIRTUAL_PAGES_RESERVED 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> Backend - Backend configuration
+
+// <i> Configure which nrf_fstorage backend is used by FDS to write to flash.
+//==========================================================
+// <o> FDS_BACKEND  - FDS flash backend.
+
+// <i> NRF_FSTORAGE_SD uses the nrf_fstorage_sd backend implementation using the SoftDevice API. Use this if you have a SoftDevice present.
+// <i> NRF_FSTORAGE_NVMC uses the nrf_fstorage_nvmc implementation. Use this setting if you don't use the SoftDevice.
+// <1=> NRF_FSTORAGE_NVMC
+// <2=> NRF_FSTORAGE_SD
+
+#ifndef FDS_BACKEND
+#define FDS_BACKEND 2
+#endif
+
+// </h>
+//==========================================================
+
+// <h> Queue - Queue settings
+
+//==========================================================
+// <o> FDS_OP_QUEUE_SIZE - Size of the internal queue.
+// <i> Increase this value if you frequently get synchronous FDS_ERR_NO_SPACE_IN_QUEUES errors.
+
+#ifndef FDS_OP_QUEUE_SIZE
+#define FDS_OP_QUEUE_SIZE 4
+#endif
+
+// </h>
+//==========================================================
+
+// <h> CRC - CRC functionality
+
+//==========================================================
+// <e> FDS_CRC_CHECK_ON_READ - Enable CRC checks.
+
+// <i> Save a record's CRC when it is written to flash and check it when the record is opened.
+// <i> Records with an incorrect CRC can still be 'seen' by the user using FDS functions, but they cannot be opened.
+// <i> Additionally, they will not be garbage collected until they are deleted.
+//==========================================================
+#ifndef FDS_CRC_CHECK_ON_READ
+#define FDS_CRC_CHECK_ON_READ 0
+#endif
+// <o> FDS_CRC_CHECK_ON_WRITE  - Perform a CRC check on newly written records.
+
+// <i> Perform a CRC check on newly written records.
+// <i> This setting can be used to make sure that the record data was not altered while being written to flash.
+// <1=> Enabled
+// <0=> Disabled
+
+#ifndef FDS_CRC_CHECK_ON_WRITE
+#define FDS_CRC_CHECK_ON_WRITE 0
+#endif
+
+// </e>
+
+// </h>
+//==========================================================
+
+// <h> Users - Number of users
+
+//==========================================================
+// <o> FDS_MAX_USERS - Maximum number of callbacks that can be registered.
+#ifndef FDS_MAX_USERS
+#define FDS_MAX_USERS 4
+#endif
+
+// <e> NRF_FSTORAGE_ENABLED - nrf_fstorage - Flash abstraction library
+//==========================================================
+#ifndef NRF_FSTORAGE_ENABLED
+#define NRF_FSTORAGE_ENABLED 1
+#endif
+
+// <h> nrf_fstorage - Common settings
+
+// <i> Common settings to all fstorage implementations
+//==========================================================
+// <q> NRF_FSTORAGE_PARAM_CHECK_DISABLED  - Disable user input validation
+
+// <i> If selected, use ASSERT to validate user input.
+// <i> This effectively removes user input validation in production code.
+// <i> Recommended setting: OFF, only enable this setting if size is a major concern.
+
+#ifndef NRF_FSTORAGE_PARAM_CHECK_DISABLED
+#define NRF_FSTORAGE_PARAM_CHECK_DISABLED 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> nrf_fstorage_sd - Implementation using the SoftDevice
+
+// <i> Configuration options for the fstorage implementation using the SoftDevice
+//==========================================================
+// <o> NRF_FSTORAGE_SD_QUEUE_SIZE - Size of the internal queue of operations
+// <i> Increase this value if API calls frequently return the error @ref NRF_ERROR_NO_MEM.
+
+#ifndef NRF_FSTORAGE_SD_QUEUE_SIZE
+#define NRF_FSTORAGE_SD_QUEUE_SIZE 4
+#endif
+
+// <o> NRF_FSTORAGE_SD_MAX_RETRIES - Maximum number of attempts at executing an operation when the SoftDevice is busy
+// <i> Increase this value if events frequently return the @ref NRF_ERROR_TIMEOUT error.
+// <i> The SoftDevice might fail to schedule flash access due to high BLE activity.
+
+#ifndef NRF_FSTORAGE_SD_MAX_RETRIES
+#define NRF_FSTORAGE_SD_MAX_RETRIES 8
+#endif
+
+// <o> NRF_FSTORAGE_SD_MAX_WRITE_SIZE - Maximum number of bytes to be written to flash in a single operation
+// <i> This value must be a multiple of four.
+// <i> Lowering this value can increase the chances of the SoftDevice being able to execute flash operations in between radio activity.
+// <i> This value is bound by the maximum number of bytes that can be written to flash in a single call to @ref sd_flash_write.
+// <i> That is 1024 bytes for nRF51 ICs and 4096 bytes for nRF52 ICs.
+
+#ifndef NRF_FSTORAGE_SD_MAX_WRITE_SIZE
+#define NRF_FSTORAGE_SD_MAX_WRITE_SIZE 4096
+#endif
+
+// </e>
+
+// <e> NRF_SDH_SOC_ENABLED - nrf_sdh_soc - SoftDevice SoC event handler
+//==========================================================
+#ifndef NRF_SDH_SOC_ENABLED
+#define NRF_SDH_SOC_ENABLED 1
+#endif
+// <h> SoC Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_SOC_OBSERVER_PRIO_LEVELS - Total number of priority levels for SoC observers.
+// <i> This setting configures the number of priority levels available for the SoC event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_SOC_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_SOC_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <h> SoC Observers priorities - Invididual priorities
+
+// <e> NRF_SDH_ENABLED - nrf_sdh - SoftDevice handler
+//==========================================================
+#ifndef NRF_SDH_ENABLED
+#define NRF_SDH_ENABLED 1
+#endif
+// <h> Dispatch model
+
+// <i> This setting configures how Stack events are dispatched to the application.
+//==========================================================
+// <o> NRF_SDH_DISPATCH_MODEL
+
+// <i> NRF_SDH_DISPATCH_MODEL_INTERRUPT: SoftDevice events are passed to the application from the interrupt context.
+// <i> NRF_SDH_DISPATCH_MODEL_APPSH: SoftDevice events are scheduled using @ref app_scheduler.
+// <i> NRF_SDH_DISPATCH_MODEL_POLLING: SoftDevice events are to be fetched manually.
+// <0=> NRF_SDH_DISPATCH_MODEL_INTERRUPT
+// <1=> NRF_SDH_DISPATCH_MODEL_APPSH
+// <2=> NRF_SDH_DISPATCH_MODEL_POLLING
+
+#ifndef NRF_SDH_DISPATCH_MODEL
+#define NRF_SDH_DISPATCH_MODEL 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> Clock - SoftDevice clock configuration
+
+//==========================================================
+// <o> NRF_SDH_CLOCK_LF_SRC  - SoftDevice clock source.
+
+// <0=> NRF_CLOCK_LF_SRC_RC
+// <1=> NRF_CLOCK_LF_SRC_XTAL
+// <2=> NRF_CLOCK_LF_SRC_SYNTH
+
+#ifndef NRF_SDH_CLOCK_LF_SRC
+#define NRF_SDH_CLOCK_LF_SRC 1
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_CTIV - SoftDevice calibration timer interval.
+#ifndef NRF_SDH_CLOCK_LF_RC_CTIV
+#define NRF_SDH_CLOCK_LF_RC_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_TEMP_CTIV - SoftDevice calibration timer interval under constant temperature.
+// <i> How often (in number of calibration intervals) the RC oscillator shall be calibrated
+// <i>  if the temperature has not changed.
+
+#ifndef NRF_SDH_CLOCK_LF_RC_TEMP_CTIV
+#define NRF_SDH_CLOCK_LF_RC_TEMP_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_ACCURACY  - External clock accuracy used in the LL to compute timing.
+
+// <0=> NRF_CLOCK_LF_ACCURACY_250_PPM
+// <1=> NRF_CLOCK_LF_ACCURACY_500_PPM
+// <2=> NRF_CLOCK_LF_ACCURACY_150_PPM
+// <3=> NRF_CLOCK_LF_ACCURACY_100_PPM
+// <4=> NRF_CLOCK_LF_ACCURACY_75_PPM
+// <5=> NRF_CLOCK_LF_ACCURACY_50_PPM
+// <6=> NRF_CLOCK_LF_ACCURACY_30_PPM
+// <7=> NRF_CLOCK_LF_ACCURACY_20_PPM
+// <8=> NRF_CLOCK_LF_ACCURACY_10_PPM
+// <9=> NRF_CLOCK_LF_ACCURACY_5_PPM
+// <10=> NRF_CLOCK_LF_ACCURACY_2_PPM
+// <11=> NRF_CLOCK_LF_ACCURACY_1_PPM
+
+#ifndef NRF_SDH_CLOCK_LF_ACCURACY
+#define NRF_SDH_CLOCK_LF_ACCURACY 7
+#endif
+
+// <o> NRF_SDH_SOC_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which SoC events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have SoC events dispatched before or after other stack events, such as ANT or BLE.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_SOC_STACK_OBSERVER_PRIO
+#define NRF_SDH_SOC_STACK_OBSERVER_PRIO 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> SDH Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_REQ_OBSERVER_PRIO_LEVELS - Total number of priority levels for request observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice request event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_REQ_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_REQ_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_STATE_OBSERVER_PRIO_LEVELS - Total number of priority levels for state observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice state event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STATE_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STATE_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_STACK_OBSERVER_PRIO_LEVELS - Total number of priority levels for stack event observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice stack event handlers (ANT, BLE, SoC).
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STACK_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
+#endif
+
+#ifndef NRF_SECTION_ITER_ENABLED
+#define NRF_SECTION_ITER_ENABLED 1
+#endif
+
+#ifndef APP_SCHEDULER_ENABLED
+#define APP_SCHEDULER_ENABLED 1
+#endif
+
+// <e> MEM_MANAGER_ENABLED - mem_manager - Dynamic memory allocator
+//==========================================================
+#ifndef MEM_MANAGER_ENABLED
+#define MEM_MANAGER_ENABLED 1
+#endif
+// <o> MEMORY_MANAGER_SMALL_BLOCK_COUNT - Size of each memory blocks identified as 'small' block.  <0-255>
+
+#ifndef MEMORY_MANAGER_SMALL_BLOCK_COUNT
+#define MEMORY_MANAGER_SMALL_BLOCK_COUNT 8
+#endif
+
+// <o> MEMORY_MANAGER_SMALL_BLOCK_SIZE -  Size of each memory blocks identified as 'small' block.
+// <i>  Size of each memory blocks identified as 'small' block. Memory block are recommended to be word-sized.
+
+#ifndef MEMORY_MANAGER_SMALL_BLOCK_SIZE
+#define MEMORY_MANAGER_SMALL_BLOCK_SIZE 64
+#endif
+
+// <o> MEMORY_MANAGER_MEDIUM_BLOCK_COUNT - Size of each memory blocks identified as 'medium' block.  <0-255>
+
+#ifndef MEMORY_MANAGER_MEDIUM_BLOCK_COUNT
+#define MEMORY_MANAGER_MEDIUM_BLOCK_COUNT 4
+#endif
+
+// <o> MEMORY_MANAGER_MEDIUM_BLOCK_SIZE -  Size of each memory blocks identified as 'medium' block.
+// <i>  Size of each memory blocks identified as 'medium' block. Memory block are recommended to be word-sized.
+
+#ifndef MEMORY_MANAGER_MEDIUM_BLOCK_SIZE
+#define MEMORY_MANAGER_MEDIUM_BLOCK_SIZE 256
+#endif
+
+// <o> MEMORY_MANAGER_LARGE_BLOCK_COUNT - Size of each memory blocks identified as 'large' block.  <0-255>
+
+#ifndef MEMORY_MANAGER_LARGE_BLOCK_COUNT
+#define MEMORY_MANAGER_LARGE_BLOCK_COUNT 2
+#endif
+
+// <o> MEMORY_MANAGER_LARGE_BLOCK_SIZE -  Size of each memory blocks identified as 'large' block.
+// <i>  Size of each memory blocks identified as 'large' block. Memory block are recommended to be word-sized.
+
+#ifndef MEMORY_MANAGER_LARGE_BLOCK_SIZE
+#define MEMORY_MANAGER_LARGE_BLOCK_SIZE 1280
+#endif
+
+// <o> MEMORY_MANAGER_XLARGE_BLOCK_COUNT - Size of each memory blocks identified as 'extra large' block.  <0-255>
+
+#ifndef MEMORY_MANAGER_XLARGE_BLOCK_COUNT
+#define MEMORY_MANAGER_XLARGE_BLOCK_COUNT 0
+#endif
+
+// <o> MEMORY_MANAGER_XLARGE_BLOCK_SIZE -  Size of each memory blocks identified as 'extra large' block.
+// <i>  Size of each memory blocks identified as 'extra large' block. Memory block are recommended to be word-sized.
+
+#ifndef MEMORY_MANAGER_XLARGE_BLOCK_SIZE
+#define MEMORY_MANAGER_XLARGE_BLOCK_SIZE 1320
+#endif
+
+// <o> MEMORY_MANAGER_XXLARGE_BLOCK_COUNT - Size of each memory blocks identified as 'extra extra large' block.  <0-255>
+
+#ifndef MEMORY_MANAGER_XXLARGE_BLOCK_COUNT
+#define MEMORY_MANAGER_XXLARGE_BLOCK_COUNT 0
+#endif
+
+// <o> MEMORY_MANAGER_XXLARGE_BLOCK_SIZE -  Size of each memory blocks identified as 'extra extra large' block.
+// <i>  Size of each memory blocks identified as 'extra extra large' block. Memory block are recommended to be word-sized.
+
+#ifndef MEMORY_MANAGER_XXLARGE_BLOCK_SIZE
+#define MEMORY_MANAGER_XXLARGE_BLOCK_SIZE 3444
+#endif
+
+// <o> MEMORY_MANAGER_XSMALL_BLOCK_COUNT - Size of each memory blocks identified as 'extra small' block.  <0-255>
+
+#ifndef MEMORY_MANAGER_XSMALL_BLOCK_COUNT
+#define MEMORY_MANAGER_XSMALL_BLOCK_COUNT 0
+#endif
+
+// <o> MEMORY_MANAGER_XSMALL_BLOCK_SIZE -  Size of each memory blocks identified as 'extra small' block.
+// <i>  Size of each memory blocks identified as 'extra large' block. Memory block are recommended to be word-sized.
+
+#ifndef MEMORY_MANAGER_XSMALL_BLOCK_SIZE
+#define MEMORY_MANAGER_XSMALL_BLOCK_SIZE 64
+#endif
+
+// <o> MEMORY_MANAGER_XXSMALL_BLOCK_COUNT - Size of each memory blocks identified as 'extra extra small' block.  <0-255>
+
+#ifndef MEMORY_MANAGER_XXSMALL_BLOCK_COUNT
+#define MEMORY_MANAGER_XXSMALL_BLOCK_COUNT 0
+#endif
+
+// <o> MEMORY_MANAGER_XXSMALL_BLOCK_SIZE -  Size of each memory blocks identified as 'extra extra small' block.
+// <i>  Size of each memory blocks identified as 'extra extra small' block. Memory block are recommended to be word-sized.
+
+#ifndef MEMORY_MANAGER_XXSMALL_BLOCK_SIZE
+#define MEMORY_MANAGER_XXSMALL_BLOCK_SIZE 32
+#endif
+
+#endif // SDK_CONFIG_H

--- a/ci/libraries_tests/nrf5_ble_srv_gatts_c/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_gatts_c/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_ble_srv_gls/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_gls/CMakeLists.txt
@@ -1,0 +1,64 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# WARNING: FILE GENERATED FROM ./ci/scripts/generate_cmake_tests.sh SCRIPT.
+
+cmake_minimum_required(VERSION 3.14)
+project(nrf5_ble_srv_gls_test LANGUAGES C ASM)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../../cmake")
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME} "main.c")
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_racp
+  nrf5_ble_srv_gls
+  nrf5_config
+  nrf5_delay
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+    nrf5_balloc
+    nrf5_balloc_fwd
+    nrf5_ble_gq
+    nrf5_cli_fwd
+    nrf5_ext_fprintf
+    nrf5_memobj
+    nrf5_memobj_fwd
+    nrf5_queue
+  )
+endif()

--- a/ci/libraries_tests/nrf5_ble_srv_gls/main.c
+++ b/ci/libraries_tests/nrf5_ble_srv_gls/main.c
@@ -1,0 +1,13 @@
+#include "ble_gls.h"
+
+void app_error_handler_bare(uint32_t error_code)
+{
+}
+
+int main()
+{
+    ble_gls_t gls;
+    ble_gls_init_t gls_init;
+    ble_gls_init(&gls, &gls_init);
+    return 0;
+}

--- a/ci/libraries_tests/nrf5_ble_srv_gls/sdk_config.h
+++ b/ci/libraries_tests/nrf5_ble_srv_gls/sdk_config.h
@@ -1,0 +1,233 @@
+#ifndef SDK_CONFIG_H
+#define SDK_CONFIG_H
+
+#ifndef NRF_LOG_ENABLED
+#define NRF_LOG_ENABLED 0
+#endif
+
+// </h>
+//==========================================================
+
+// </h>
+//==========================================================
+
+// <h> nRF_SoftDevice
+
+//==========================================================
+// <e> NRF_SDH_BLE_ENABLED - nrf_sdh_ble - SoftDevice BLE event handler
+//==========================================================
+#ifndef NRF_SDH_BLE_ENABLED
+#define NRF_SDH_BLE_ENABLED 1
+#endif
+// <h> BLE Stack configuration - Stack configuration parameters
+
+// <i> The SoftDevice handler will configure the stack with these parameters when calling @ref nrf_sdh_ble_default_cfg_set.
+// <i> Other libraries might depend on these values; keep them up-to-date even if you are not explicitely calling @ref nrf_sdh_ble_default_cfg_set.
+//==========================================================
+// <o> NRF_SDH_BLE_GAP_DATA_LENGTH   <27-251>
+
+// <i> Requested BLE GAP data length to be negotiated.
+
+#ifndef NRF_SDH_BLE_GAP_DATA_LENGTH
+#define NRF_SDH_BLE_GAP_DATA_LENGTH 27
+#endif
+
+// <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links.
+#ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links.
+#ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count.
+// <i> Maximum number of total concurrent connections using the default configuration.
+
+#ifndef NRF_SDH_BLE_TOTAL_LINK_COUNT
+#define NRF_SDH_BLE_TOTAL_LINK_COUNT 1
+#endif
+
+// <o> NRF_SDH_BLE_GAP_EVENT_LENGTH - GAP event length.
+// <i> The time set aside for this connection on every connection interval in 1.25 ms units.
+
+#ifndef NRF_SDH_BLE_GAP_EVENT_LENGTH
+#define NRF_SDH_BLE_GAP_EVENT_LENGTH 6
+#endif
+
+// <o> NRF_SDH_BLE_GATT_MAX_MTU_SIZE - Static maximum MTU size.
+#ifndef NRF_SDH_BLE_GATT_MAX_MTU_SIZE
+#define NRF_SDH_BLE_GATT_MAX_MTU_SIZE 23
+#endif
+
+// <o> NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE - Attribute Table size in bytes. The size must be a multiple of 4.
+#ifndef NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE
+#define NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE 1408
+#endif
+
+// <o> NRF_SDH_BLE_VS_UUID_COUNT - The number of vendor-specific UUIDs.
+#ifndef NRF_SDH_BLE_VS_UUID_COUNT
+#define NRF_SDH_BLE_VS_UUID_COUNT 0
+#endif
+
+// <q> NRF_SDH_BLE_SERVICE_CHANGED  - Include the Service Changed characteristic in the Attribute Table.
+
+#ifndef NRF_SDH_BLE_SERVICE_CHANGED
+#define NRF_SDH_BLE_SERVICE_CHANGED 0
+#endif
+
+// <e> NRF_SDH_SOC_ENABLED - nrf_sdh_soc - SoftDevice SoC event handler
+//==========================================================
+#ifndef NRF_SDH_SOC_ENABLED
+#define NRF_SDH_SOC_ENABLED 1
+#endif
+// <h> SoC Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_SOC_OBSERVER_PRIO_LEVELS - Total number of priority levels for SoC observers.
+// <i> This setting configures the number of priority levels available for the SoC event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_SOC_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_SOC_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <h> SoC Observers priorities - Invididual priorities
+
+// <e> NRF_SDH_ENABLED - nrf_sdh - SoftDevice handler
+//==========================================================
+#ifndef NRF_SDH_ENABLED
+#define NRF_SDH_ENABLED 1
+#endif
+
+// </h>
+//==========================================================
+
+// <h> Clock - SoftDevice clock configuration
+
+//==========================================================
+// <o> NRF_SDH_CLOCK_LF_SRC  - SoftDevice clock source.
+
+// <0=> NRF_CLOCK_LF_SRC_RC
+// <1=> NRF_CLOCK_LF_SRC_XTAL
+// <2=> NRF_CLOCK_LF_SRC_SYNTH
+
+#ifndef NRF_SDH_CLOCK_LF_SRC
+#define NRF_SDH_CLOCK_LF_SRC 1
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_CTIV - SoftDevice calibration timer interval.
+#ifndef NRF_SDH_CLOCK_LF_RC_CTIV
+#define NRF_SDH_CLOCK_LF_RC_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_TEMP_CTIV - SoftDevice calibration timer interval under constant temperature.
+// <i> How often (in number of calibration intervals) the RC oscillator shall be calibrated
+// <i>  if the temperature has not changed.
+
+#ifndef NRF_SDH_CLOCK_LF_RC_TEMP_CTIV
+#define NRF_SDH_CLOCK_LF_RC_TEMP_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_ACCURACY  - External clock accuracy used in the LL to compute timing.
+
+// <0=> NRF_CLOCK_LF_ACCURACY_250_PPM
+// <1=> NRF_CLOCK_LF_ACCURACY_500_PPM
+// <2=> NRF_CLOCK_LF_ACCURACY_150_PPM
+// <3=> NRF_CLOCK_LF_ACCURACY_100_PPM
+// <4=> NRF_CLOCK_LF_ACCURACY_75_PPM
+// <5=> NRF_CLOCK_LF_ACCURACY_50_PPM
+// <6=> NRF_CLOCK_LF_ACCURACY_30_PPM
+// <7=> NRF_CLOCK_LF_ACCURACY_20_PPM
+// <8=> NRF_CLOCK_LF_ACCURACY_10_PPM
+// <9=> NRF_CLOCK_LF_ACCURACY_5_PPM
+// <10=> NRF_CLOCK_LF_ACCURACY_2_PPM
+// <11=> NRF_CLOCK_LF_ACCURACY_1_PPM
+
+#ifndef NRF_SDH_CLOCK_LF_ACCURACY
+#define NRF_SDH_CLOCK_LF_ACCURACY 7
+#endif
+
+// <o> NRF_SDH_SOC_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which SoC events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have SoC events dispatched before or after other stack events, such as ANT or BLE.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_SOC_STACK_OBSERVER_PRIO
+#define NRF_SDH_SOC_STACK_OBSERVER_PRIO 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> BLE Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_BLE_OBSERVER_PRIO_LEVELS - Total number of priority levels for BLE observers.
+// <i> This setting configures the number of priority levels available for BLE event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_BLE_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_BLE_OBSERVER_PRIO_LEVELS 4
+#endif
+
+// <h> BLE Observers priorities - Invididual priorities
+
+//==========================================================
+// <o> BLE_ADV_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Advertising module.
+
+#ifndef BLE_ADV_BLE_OBSERVER_PRIO
+#define BLE_ADV_BLE_OBSERVER_PRIO 1
+#endif
+
+// <o> BLE_CONN_STATE_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Connection State module.
+
+#ifndef BLE_CONN_STATE_BLE_OBSERVER_PRIO
+#define BLE_CONN_STATE_BLE_OBSERVER_PRIO 0
+#endif
+
+// <o> NRF_SDH_STACK_OBSERVER_PRIO_LEVELS - Total number of priority levels for stack event observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice stack event handlers (ANT, BLE, SoC).
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STACK_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_BLE_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which BLE events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have BLE events dispatched before or after other stack events, such as ANT or SoC.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_BLE_STACK_OBSERVER_PRIO
+#define NRF_SDH_BLE_STACK_OBSERVER_PRIO 0
+#endif
+
+//---
+
+// <e> NRF_BLE_QWR_ENABLED - nrf_ble_qwr - Queued writes support module (prepare/execute write)
+//==========================================================
+#ifndef NRF_BLE_QWR_ENABLED
+#define NRF_BLE_QWR_ENABLED 1
+#endif
+// <o> NRF_BLE_QWR_MAX_ATTR - Maximum number of attribute handles that can be registered. This number must be adjusted according to the number of attributes for which Queued Writes will be enabled. If it is zero, the module will reject all Queued Write requests.
+#ifndef NRF_BLE_QWR_MAX_ATTR
+#define NRF_BLE_QWR_MAX_ATTR 1
+#endif
+
+// <q> NRF_SECTION_ITER_ENABLED  - nrf_section_iter - Section iterator
+
+#ifndef NRF_SECTION_ITER_ENABLED
+#define NRF_SECTION_ITER_ENABLED 1
+#endif
+
+//---
+
+#ifndef BLE_GLS_ENABLED
+#define BLE_GLS_ENABLED 1
+#endif
+
+#endif // SDK_CONFIG_H

--- a/ci/libraries_tests/nrf5_ble_srv_hrs/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_hrs/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_ble_srv_ias/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_ias/CMakeLists.txt
@@ -1,0 +1,52 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# WARNING: FILE GENERATED FROM ./ci/scripts/generate_cmake_tests.sh SCRIPT.
+
+cmake_minimum_required(VERSION 3.14)
+project(nrf5_ble_srv_ias_test LANGUAGES C ASM)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../../cmake")
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME} "main.c")
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_link_ctx_manager
+  nrf5_ble_srv_ias
+  nrf5_config
+  nrf5_delay
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)

--- a/ci/libraries_tests/nrf5_ble_srv_ias/main.c
+++ b/ci/libraries_tests/nrf5_ble_srv_ias/main.c
@@ -1,0 +1,13 @@
+#include "ble_ias.h"
+
+void app_error_handler_bare(uint32_t error_code)
+{
+}
+
+int main()
+{
+    ble_ias_t ias;
+    ble_ias_init_t ias_init;
+    ble_ias_init(&ias, &ias_init);
+    return 0;
+}

--- a/ci/libraries_tests/nrf5_ble_srv_ias/sdk_config.h
+++ b/ci/libraries_tests/nrf5_ble_srv_ias/sdk_config.h
@@ -1,0 +1,233 @@
+#ifndef SDK_CONFIG_H
+#define SDK_CONFIG_H
+
+#ifndef NRF_LOG_ENABLED
+#define NRF_LOG_ENABLED 0
+#endif
+
+// </h>
+//==========================================================
+
+// </h>
+//==========================================================
+
+// <h> nRF_SoftDevice
+
+//==========================================================
+// <e> NRF_SDH_BLE_ENABLED - nrf_sdh_ble - SoftDevice BLE event handler
+//==========================================================
+#ifndef NRF_SDH_BLE_ENABLED
+#define NRF_SDH_BLE_ENABLED 1
+#endif
+// <h> BLE Stack configuration - Stack configuration parameters
+
+// <i> The SoftDevice handler will configure the stack with these parameters when calling @ref nrf_sdh_ble_default_cfg_set.
+// <i> Other libraries might depend on these values; keep them up-to-date even if you are not explicitely calling @ref nrf_sdh_ble_default_cfg_set.
+//==========================================================
+// <o> NRF_SDH_BLE_GAP_DATA_LENGTH   <27-251>
+
+// <i> Requested BLE GAP data length to be negotiated.
+
+#ifndef NRF_SDH_BLE_GAP_DATA_LENGTH
+#define NRF_SDH_BLE_GAP_DATA_LENGTH 27
+#endif
+
+// <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links.
+#ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links.
+#ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count.
+// <i> Maximum number of total concurrent connections using the default configuration.
+
+#ifndef NRF_SDH_BLE_TOTAL_LINK_COUNT
+#define NRF_SDH_BLE_TOTAL_LINK_COUNT 1
+#endif
+
+// <o> NRF_SDH_BLE_GAP_EVENT_LENGTH - GAP event length.
+// <i> The time set aside for this connection on every connection interval in 1.25 ms units.
+
+#ifndef NRF_SDH_BLE_GAP_EVENT_LENGTH
+#define NRF_SDH_BLE_GAP_EVENT_LENGTH 6
+#endif
+
+// <o> NRF_SDH_BLE_GATT_MAX_MTU_SIZE - Static maximum MTU size.
+#ifndef NRF_SDH_BLE_GATT_MAX_MTU_SIZE
+#define NRF_SDH_BLE_GATT_MAX_MTU_SIZE 23
+#endif
+
+// <o> NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE - Attribute Table size in bytes. The size must be a multiple of 4.
+#ifndef NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE
+#define NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE 1408
+#endif
+
+// <o> NRF_SDH_BLE_VS_UUID_COUNT - The number of vendor-specific UUIDs.
+#ifndef NRF_SDH_BLE_VS_UUID_COUNT
+#define NRF_SDH_BLE_VS_UUID_COUNT 0
+#endif
+
+// <q> NRF_SDH_BLE_SERVICE_CHANGED  - Include the Service Changed characteristic in the Attribute Table.
+
+#ifndef NRF_SDH_BLE_SERVICE_CHANGED
+#define NRF_SDH_BLE_SERVICE_CHANGED 0
+#endif
+
+// <e> NRF_SDH_SOC_ENABLED - nrf_sdh_soc - SoftDevice SoC event handler
+//==========================================================
+#ifndef NRF_SDH_SOC_ENABLED
+#define NRF_SDH_SOC_ENABLED 1
+#endif
+// <h> SoC Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_SOC_OBSERVER_PRIO_LEVELS - Total number of priority levels for SoC observers.
+// <i> This setting configures the number of priority levels available for the SoC event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_SOC_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_SOC_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <h> SoC Observers priorities - Invididual priorities
+
+// <e> NRF_SDH_ENABLED - nrf_sdh - SoftDevice handler
+//==========================================================
+#ifndef NRF_SDH_ENABLED
+#define NRF_SDH_ENABLED 1
+#endif
+
+// </h>
+//==========================================================
+
+// <h> Clock - SoftDevice clock configuration
+
+//==========================================================
+// <o> NRF_SDH_CLOCK_LF_SRC  - SoftDevice clock source.
+
+// <0=> NRF_CLOCK_LF_SRC_RC
+// <1=> NRF_CLOCK_LF_SRC_XTAL
+// <2=> NRF_CLOCK_LF_SRC_SYNTH
+
+#ifndef NRF_SDH_CLOCK_LF_SRC
+#define NRF_SDH_CLOCK_LF_SRC 1
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_CTIV - SoftDevice calibration timer interval.
+#ifndef NRF_SDH_CLOCK_LF_RC_CTIV
+#define NRF_SDH_CLOCK_LF_RC_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_TEMP_CTIV - SoftDevice calibration timer interval under constant temperature.
+// <i> How often (in number of calibration intervals) the RC oscillator shall be calibrated
+// <i>  if the temperature has not changed.
+
+#ifndef NRF_SDH_CLOCK_LF_RC_TEMP_CTIV
+#define NRF_SDH_CLOCK_LF_RC_TEMP_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_ACCURACY  - External clock accuracy used in the LL to compute timing.
+
+// <0=> NRF_CLOCK_LF_ACCURACY_250_PPM
+// <1=> NRF_CLOCK_LF_ACCURACY_500_PPM
+// <2=> NRF_CLOCK_LF_ACCURACY_150_PPM
+// <3=> NRF_CLOCK_LF_ACCURACY_100_PPM
+// <4=> NRF_CLOCK_LF_ACCURACY_75_PPM
+// <5=> NRF_CLOCK_LF_ACCURACY_50_PPM
+// <6=> NRF_CLOCK_LF_ACCURACY_30_PPM
+// <7=> NRF_CLOCK_LF_ACCURACY_20_PPM
+// <8=> NRF_CLOCK_LF_ACCURACY_10_PPM
+// <9=> NRF_CLOCK_LF_ACCURACY_5_PPM
+// <10=> NRF_CLOCK_LF_ACCURACY_2_PPM
+// <11=> NRF_CLOCK_LF_ACCURACY_1_PPM
+
+#ifndef NRF_SDH_CLOCK_LF_ACCURACY
+#define NRF_SDH_CLOCK_LF_ACCURACY 7
+#endif
+
+// <o> NRF_SDH_SOC_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which SoC events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have SoC events dispatched before or after other stack events, such as ANT or BLE.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_SOC_STACK_OBSERVER_PRIO
+#define NRF_SDH_SOC_STACK_OBSERVER_PRIO 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> BLE Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_BLE_OBSERVER_PRIO_LEVELS - Total number of priority levels for BLE observers.
+// <i> This setting configures the number of priority levels available for BLE event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_BLE_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_BLE_OBSERVER_PRIO_LEVELS 4
+#endif
+
+// <h> BLE Observers priorities - Invididual priorities
+
+//==========================================================
+// <o> BLE_ADV_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Advertising module.
+
+#ifndef BLE_ADV_BLE_OBSERVER_PRIO
+#define BLE_ADV_BLE_OBSERVER_PRIO 1
+#endif
+
+// <o> BLE_CONN_STATE_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Connection State module.
+
+#ifndef BLE_CONN_STATE_BLE_OBSERVER_PRIO
+#define BLE_CONN_STATE_BLE_OBSERVER_PRIO 0
+#endif
+
+// <o> NRF_SDH_STACK_OBSERVER_PRIO_LEVELS - Total number of priority levels for stack event observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice stack event handlers (ANT, BLE, SoC).
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STACK_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_BLE_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which BLE events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have BLE events dispatched before or after other stack events, such as ANT or SoC.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_BLE_STACK_OBSERVER_PRIO
+#define NRF_SDH_BLE_STACK_OBSERVER_PRIO 0
+#endif
+
+//---
+
+// <e> NRF_BLE_QWR_ENABLED - nrf_ble_qwr - Queued writes support module (prepare/execute write)
+//==========================================================
+#ifndef NRF_BLE_QWR_ENABLED
+#define NRF_BLE_QWR_ENABLED 1
+#endif
+// <o> NRF_BLE_QWR_MAX_ATTR - Maximum number of attribute handles that can be registered. This number must be adjusted according to the number of attributes for which Queued Writes will be enabled. If it is zero, the module will reject all Queued Write requests.
+#ifndef NRF_BLE_QWR_MAX_ATTR
+#define NRF_BLE_QWR_MAX_ATTR 1
+#endif
+
+// <q> NRF_SECTION_ITER_ENABLED  - nrf_section_iter - Section iterator
+
+#ifndef NRF_SECTION_ITER_ENABLED
+#define NRF_SECTION_ITER_ENABLED 1
+#endif
+
+//---
+
+#ifndef BLE_IAS_ENABLED
+#define BLE_IAS_ENABLED 1
+#endif
+
+#endif // SDK_CONFIG_H

--- a/ci/libraries_tests/nrf5_ble_srv_ias_c/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_ias_c/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_ble_srv_lbs_c/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_lbs_c/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_ble_srv_nus_c/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_nus_c/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_ble_srv_ots/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_ots/CMakeLists.txt
@@ -1,0 +1,71 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# WARNING: FILE GENERATED FROM ./ci/scripts/generate_cmake_tests.sh SCRIPT.
+# WARNING: This test contains custom patch to allow compilation. Please edit
+#          above script if there is a need to do it.
+
+cmake_minimum_required(VERSION 3.14)
+project(nrf5_ble_srv_ots_test LANGUAGES C ASM)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../../cmake")
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME} "main.c")
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_srv_ots
+  nrf5_config
+  nrf5_crc16
+  nrf5_crc32
+  nrf5_delay
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_fstorage_sd
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+    nrf5_balloc
+    nrf5_balloc_fwd
+    nrf5_ble_gq
+    nrf5_cli_fwd
+    nrf5_ext_fprintf
+    nrf5_memobj
+    nrf5_memobj_fwd
+    nrf5_queue
+  )
+endif()

--- a/ci/libraries_tests/nrf5_ble_srv_ots/main.c
+++ b/ci/libraries_tests/nrf5_ble_srv_ots/main.c
@@ -1,0 +1,21 @@
+#include "ble_ots.h"
+#include "ble_ots_l2cap.h"
+#include "ble_ots_oacp.h"
+#include "ble_ots_object.h"
+
+void app_error_handler_bare(uint32_t error_code)
+{
+}
+
+void app_error_fault_handler(uint32_t id, uint32_t pc, uint32_t info)
+{
+}
+
+int main()
+{
+    ble_ots_init(NULL, NULL);
+    ble_ots_l2cap_is_channel_available(NULL);
+    ble_ots_oacp_on_ble_evt(NULL, NULL);
+    ble_ots_object_representation_init(NULL, NULL);
+    return 0;
+}

--- a/ci/libraries_tests/nrf5_ble_srv_ots/sdk_config.h
+++ b/ci/libraries_tests/nrf5_ble_srv_ots/sdk_config.h
@@ -1,0 +1,677 @@
+#ifndef SDK_CONFIG_H
+#define SDK_CONFIG_H
+
+#ifndef NRF_LOG_ENABLED
+#define NRF_LOG_ENABLED 0
+#endif
+
+// </h>
+//==========================================================
+
+// </h>
+//==========================================================
+
+// <h> nRF_SoftDevice
+
+//==========================================================
+// <e> NRF_SDH_BLE_ENABLED - nrf_sdh_ble - SoftDevice BLE event handler
+//==========================================================
+#ifndef NRF_SDH_BLE_ENABLED
+#define NRF_SDH_BLE_ENABLED 1
+#endif
+// <h> BLE Stack configuration - Stack configuration parameters
+
+// <i> The SoftDevice handler will configure the stack with these parameters when calling @ref nrf_sdh_ble_default_cfg_set.
+// <i> Other libraries might depend on these values; keep them up-to-date even if you are not explicitely calling @ref nrf_sdh_ble_default_cfg_set.
+//==========================================================
+// <o> NRF_SDH_BLE_GAP_DATA_LENGTH   <27-251>
+
+// <i> Requested BLE GAP data length to be negotiated.
+
+#ifndef NRF_SDH_BLE_GAP_DATA_LENGTH
+#define NRF_SDH_BLE_GAP_DATA_LENGTH 27
+#endif
+
+// <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links.
+#ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links.
+#ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count.
+// <i> Maximum number of total concurrent connections using the default configuration.
+
+#ifndef NRF_SDH_BLE_TOTAL_LINK_COUNT
+#define NRF_SDH_BLE_TOTAL_LINK_COUNT 1
+#endif
+
+// <o> NRF_SDH_BLE_GAP_EVENT_LENGTH - GAP event length.
+// <i> The time set aside for this connection on every connection interval in 1.25 ms units.
+
+#ifndef NRF_SDH_BLE_GAP_EVENT_LENGTH
+#define NRF_SDH_BLE_GAP_EVENT_LENGTH 6
+#endif
+
+// <o> NRF_SDH_BLE_GATT_MAX_MTU_SIZE - Static maximum MTU size.
+#ifndef NRF_SDH_BLE_GATT_MAX_MTU_SIZE
+#define NRF_SDH_BLE_GATT_MAX_MTU_SIZE 23
+#endif
+
+// <o> NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE - Attribute Table size in bytes. The size must be a multiple of 4.
+#ifndef NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE
+#define NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE 1408
+#endif
+
+// <o> NRF_SDH_BLE_VS_UUID_COUNT - The number of vendor-specific UUIDs.
+#ifndef NRF_SDH_BLE_VS_UUID_COUNT
+#define NRF_SDH_BLE_VS_UUID_COUNT 0
+#endif
+
+// <q> NRF_SDH_BLE_SERVICE_CHANGED  - Include the Service Changed characteristic in the Attribute Table.
+
+#ifndef NRF_SDH_BLE_SERVICE_CHANGED
+#define NRF_SDH_BLE_SERVICE_CHANGED 0
+#endif
+
+// <e> NRF_SDH_SOC_ENABLED - nrf_sdh_soc - SoftDevice SoC event handler
+//==========================================================
+#ifndef NRF_SDH_SOC_ENABLED
+#define NRF_SDH_SOC_ENABLED 1
+#endif
+// <h> SoC Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_SOC_OBSERVER_PRIO_LEVELS - Total number of priority levels for SoC observers.
+// <i> This setting configures the number of priority levels available for the SoC event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_SOC_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_SOC_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <h> SoC Observers priorities - Invididual priorities
+
+// <e> NRF_SDH_ENABLED - nrf_sdh - SoftDevice handler
+//==========================================================
+#ifndef NRF_SDH_ENABLED
+#define NRF_SDH_ENABLED 1
+#endif
+
+// </h>
+//==========================================================
+
+// <h> Clock - SoftDevice clock configuration
+
+//==========================================================
+// <o> NRF_SDH_CLOCK_LF_SRC  - SoftDevice clock source.
+
+// <0=> NRF_CLOCK_LF_SRC_RC
+// <1=> NRF_CLOCK_LF_SRC_XTAL
+// <2=> NRF_CLOCK_LF_SRC_SYNTH
+
+#ifndef NRF_SDH_CLOCK_LF_SRC
+#define NRF_SDH_CLOCK_LF_SRC 1
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_CTIV - SoftDevice calibration timer interval.
+#ifndef NRF_SDH_CLOCK_LF_RC_CTIV
+#define NRF_SDH_CLOCK_LF_RC_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_TEMP_CTIV - SoftDevice calibration timer interval under constant temperature.
+// <i> How often (in number of calibration intervals) the RC oscillator shall be calibrated
+// <i>  if the temperature has not changed.
+
+#ifndef NRF_SDH_CLOCK_LF_RC_TEMP_CTIV
+#define NRF_SDH_CLOCK_LF_RC_TEMP_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_ACCURACY  - External clock accuracy used in the LL to compute timing.
+
+// <0=> NRF_CLOCK_LF_ACCURACY_250_PPM
+// <1=> NRF_CLOCK_LF_ACCURACY_500_PPM
+// <2=> NRF_CLOCK_LF_ACCURACY_150_PPM
+// <3=> NRF_CLOCK_LF_ACCURACY_100_PPM
+// <4=> NRF_CLOCK_LF_ACCURACY_75_PPM
+// <5=> NRF_CLOCK_LF_ACCURACY_50_PPM
+// <6=> NRF_CLOCK_LF_ACCURACY_30_PPM
+// <7=> NRF_CLOCK_LF_ACCURACY_20_PPM
+// <8=> NRF_CLOCK_LF_ACCURACY_10_PPM
+// <9=> NRF_CLOCK_LF_ACCURACY_5_PPM
+// <10=> NRF_CLOCK_LF_ACCURACY_2_PPM
+// <11=> NRF_CLOCK_LF_ACCURACY_1_PPM
+
+#ifndef NRF_SDH_CLOCK_LF_ACCURACY
+#define NRF_SDH_CLOCK_LF_ACCURACY 7
+#endif
+
+// <o> NRF_SDH_SOC_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which SoC events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have SoC events dispatched before or after other stack events, such as ANT or BLE.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_SOC_STACK_OBSERVER_PRIO
+#define NRF_SDH_SOC_STACK_OBSERVER_PRIO 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> BLE Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_BLE_OBSERVER_PRIO_LEVELS - Total number of priority levels for BLE observers.
+// <i> This setting configures the number of priority levels available for BLE event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_BLE_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_BLE_OBSERVER_PRIO_LEVELS 4
+#endif
+
+// <h> BLE Observers priorities - Invididual priorities
+
+//==========================================================
+// <o> BLE_ADV_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Advertising module.
+
+#ifndef BLE_ADV_BLE_OBSERVER_PRIO
+#define BLE_ADV_BLE_OBSERVER_PRIO 1
+#endif
+
+// <o> BLE_CONN_STATE_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Connection State module.
+
+#ifndef BLE_CONN_STATE_BLE_OBSERVER_PRIO
+#define BLE_CONN_STATE_BLE_OBSERVER_PRIO 0
+#endif
+
+// <o> NRF_SDH_STACK_OBSERVER_PRIO_LEVELS - Total number of priority levels for stack event observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice stack event handlers (ANT, BLE, SoC).
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STACK_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_BLE_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which BLE events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have BLE events dispatched before or after other stack events, such as ANT or SoC.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_BLE_STACK_OBSERVER_PRIO
+#define NRF_SDH_BLE_STACK_OBSERVER_PRIO 0
+#endif
+
+//---
+
+// <e> NRF_BLE_QWR_ENABLED - nrf_ble_qwr - Queued writes support module (prepare/execute write)
+//==========================================================
+#ifndef NRF_BLE_QWR_ENABLED
+#define NRF_BLE_QWR_ENABLED 1
+#endif
+// <o> NRF_BLE_QWR_MAX_ATTR - Maximum number of attribute handles that can be registered. This number must be adjusted according to the number of attributes for which Queued Writes will be enabled. If it is zero, the module will reject all Queued Write requests.
+#ifndef NRF_BLE_QWR_MAX_ATTR
+#define NRF_BLE_QWR_MAX_ATTR 1
+#endif
+
+// <q> NRF_SECTION_ITER_ENABLED  - nrf_section_iter - Section iterator
+
+#ifndef NRF_SECTION_ITER_ENABLED
+#define NRF_SECTION_ITER_ENABLED 1
+#endif
+
+// <e> FDS_ENABLED - fds - Flash data storage module
+//==========================================================
+#ifndef FDS_ENABLED
+#define FDS_ENABLED 1
+#endif
+
+// <h> Pages - Virtual page settings
+
+// <i> Configure the number of virtual pages to use and their size.
+//==========================================================
+// <o> FDS_VIRTUAL_PAGES - Number of virtual flash pages to use.
+// <i> One of the virtual pages is reserved by the system for garbage collection.
+// <i> Therefore, the minimum is two virtual pages: one page to store data and one page to be used by the system for garbage collection.
+// <i> The total amount of flash memory that is used by FDS amounts to @ref FDS_VIRTUAL_PAGES * @ref FDS_VIRTUAL_PAGE_SIZE * 4 bytes.
+
+#ifndef FDS_VIRTUAL_PAGES
+#define FDS_VIRTUAL_PAGES 3
+#endif
+
+// <o> FDS_VIRTUAL_PAGE_SIZE  - The size of a virtual flash page.
+
+// <i> Expressed in number of 4-byte words.
+// <i> By default, a virtual page is the same size as a physical page.
+// <i> The size of a virtual page must be a multiple of the size of a physical page.
+// <1024=> 1024
+// <2048=> 2048
+
+#ifndef FDS_VIRTUAL_PAGE_SIZE
+#define FDS_VIRTUAL_PAGE_SIZE 1024
+#endif
+
+// <o> FDS_VIRTUAL_PAGES_RESERVED - The number of virtual flash pages that are used by other modules.
+// <i> FDS module stores its data in the last pages of the flash memory.
+// <i> By setting this value, you can move flash end address used by the FDS.
+// <i> As a result the reserved space can be used by other modules.
+
+#ifndef FDS_VIRTUAL_PAGES_RESERVED
+#define FDS_VIRTUAL_PAGES_RESERVED 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> Backend - Backend configuration
+
+// <i> Configure which nrf_fstorage backend is used by FDS to write to flash.
+//==========================================================
+// <o> FDS_BACKEND  - FDS flash backend.
+
+// <i> NRF_FSTORAGE_SD uses the nrf_fstorage_sd backend implementation using the SoftDevice API. Use this if you have a SoftDevice present.
+// <i> NRF_FSTORAGE_NVMC uses the nrf_fstorage_nvmc implementation. Use this setting if you don't use the SoftDevice.
+// <1=> NRF_FSTORAGE_NVMC
+// <2=> NRF_FSTORAGE_SD
+
+#ifndef FDS_BACKEND
+#define FDS_BACKEND 2
+#endif
+
+// </h>
+//==========================================================
+
+// <h> Queue - Queue settings
+
+//==========================================================
+// <o> FDS_OP_QUEUE_SIZE - Size of the internal queue.
+// <i> Increase this value if you frequently get synchronous FDS_ERR_NO_SPACE_IN_QUEUES errors.
+
+#ifndef FDS_OP_QUEUE_SIZE
+#define FDS_OP_QUEUE_SIZE 4
+#endif
+
+// </h>
+//==========================================================
+
+// <h> CRC - CRC functionality
+
+//==========================================================
+// <e> FDS_CRC_CHECK_ON_READ - Enable CRC checks.
+
+// <i> Save a record's CRC when it is written to flash and check it when the record is opened.
+// <i> Records with an incorrect CRC can still be 'seen' by the user using FDS functions, but they cannot be opened.
+// <i> Additionally, they will not be garbage collected until they are deleted.
+//==========================================================
+#ifndef FDS_CRC_CHECK_ON_READ
+#define FDS_CRC_CHECK_ON_READ 0
+#endif
+// <o> FDS_CRC_CHECK_ON_WRITE  - Perform a CRC check on newly written records.
+
+// <i> Perform a CRC check on newly written records.
+// <i> This setting can be used to make sure that the record data was not altered while being written to flash.
+// <1=> Enabled
+// <0=> Disabled
+
+#ifndef FDS_CRC_CHECK_ON_WRITE
+#define FDS_CRC_CHECK_ON_WRITE 0
+#endif
+
+// </e>
+
+// </h>
+//==========================================================
+
+// <h> Users - Number of users
+
+//==========================================================
+// <o> FDS_MAX_USERS - Maximum number of callbacks that can be registered.
+#ifndef FDS_MAX_USERS
+#define FDS_MAX_USERS 4
+#endif
+
+// <e> NRF_FSTORAGE_ENABLED - nrf_fstorage - Flash abstraction library
+//==========================================================
+#ifndef NRF_FSTORAGE_ENABLED
+#define NRF_FSTORAGE_ENABLED 1
+#endif
+
+// <h> nrf_fstorage - Common settings
+
+// <i> Common settings to all fstorage implementations
+//==========================================================
+// <q> NRF_FSTORAGE_PARAM_CHECK_DISABLED  - Disable user input validation
+
+// <i> If selected, use ASSERT to validate user input.
+// <i> This effectively removes user input validation in production code.
+// <i> Recommended setting: OFF, only enable this setting if size is a major concern.
+
+#ifndef NRF_FSTORAGE_PARAM_CHECK_DISABLED
+#define NRF_FSTORAGE_PARAM_CHECK_DISABLED 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> nrf_fstorage_sd - Implementation using the SoftDevice
+
+// <i> Configuration options for the fstorage implementation using the SoftDevice
+//==========================================================
+// <o> NRF_FSTORAGE_SD_QUEUE_SIZE - Size of the internal queue of operations
+// <i> Increase this value if API calls frequently return the error @ref NRF_ERROR_NO_MEM.
+
+#ifndef NRF_FSTORAGE_SD_QUEUE_SIZE
+#define NRF_FSTORAGE_SD_QUEUE_SIZE 4
+#endif
+
+// <o> NRF_FSTORAGE_SD_MAX_RETRIES - Maximum number of attempts at executing an operation when the SoftDevice is busy
+// <i> Increase this value if events frequently return the @ref NRF_ERROR_TIMEOUT error.
+// <i> The SoftDevice might fail to schedule flash access due to high BLE activity.
+
+#ifndef NRF_FSTORAGE_SD_MAX_RETRIES
+#define NRF_FSTORAGE_SD_MAX_RETRIES 8
+#endif
+
+// <o> NRF_FSTORAGE_SD_MAX_WRITE_SIZE - Maximum number of bytes to be written to flash in a single operation
+// <i> This value must be a multiple of four.
+// <i> Lowering this value can increase the chances of the SoftDevice being able to execute flash operations in between radio activity.
+// <i> This value is bound by the maximum number of bytes that can be written to flash in a single call to @ref sd_flash_write.
+// <i> That is 1024 bytes for nRF51 ICs and 4096 bytes for nRF52 ICs.
+
+#ifndef NRF_FSTORAGE_SD_MAX_WRITE_SIZE
+#define NRF_FSTORAGE_SD_MAX_WRITE_SIZE 4096
+#endif
+
+// </e>
+
+// </h>
+//==========================================================
+
+// <h> SDH Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_REQ_OBSERVER_PRIO_LEVELS - Total number of priority levels for request observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice request event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_REQ_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_REQ_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_STATE_OBSERVER_PRIO_LEVELS - Total number of priority levels for state observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice state event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STATE_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STATE_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_STACK_OBSERVER_PRIO_LEVELS - Total number of priority levels for stack event observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice stack event handlers (ANT, BLE, SoC).
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STACK_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <e> APP_TIMER_ENABLED - app_timer - Application timer functionality
+//==========================================================
+#ifndef APP_TIMER_ENABLED
+#define APP_TIMER_ENABLED 1
+#endif
+// <o> APP_TIMER_CONFIG_RTC_FREQUENCY  - Configure RTC prescaler.
+
+// <0=> 32768 Hz
+// <1=> 16384 Hz
+// <3=> 8192 Hz
+// <7=> 4096 Hz
+// <15=> 2048 Hz
+// <31=> 1024 Hz
+
+#ifndef APP_TIMER_CONFIG_RTC_FREQUENCY
+#define APP_TIMER_CONFIG_RTC_FREQUENCY 1
+#endif
+
+// <o> APP_TIMER_CONFIG_IRQ_PRIORITY  - Interrupt priority
+
+// <i> Priorities 0,2 (nRF51) and 0,1,4,5 (nRF52) are reserved for SoftDevice
+// <0=> 0 (highest)
+// <1=> 1
+// <2=> 2
+// <3=> 3
+// <4=> 4
+// <5=> 5
+// <6=> 6
+// <7=> 7
+
+#ifndef APP_TIMER_CONFIG_IRQ_PRIORITY
+#define APP_TIMER_CONFIG_IRQ_PRIORITY 6
+#endif
+
+// <o> APP_TIMER_CONFIG_OP_QUEUE_SIZE - Capacity of timer requests queue.
+// <i> Size of the queue depends on how many timers are used
+// <i> in the system, how often timers are started and overall
+// <i> system latency. If queue size is too small app_timer calls
+// <i> will fail.
+
+#ifndef APP_TIMER_CONFIG_OP_QUEUE_SIZE
+#define APP_TIMER_CONFIG_OP_QUEUE_SIZE 10
+#endif
+
+// <q> APP_TIMER_CONFIG_USE_SCHEDULER  - Enable scheduling app_timer events to app_scheduler
+
+#ifndef APP_TIMER_CONFIG_USE_SCHEDULER
+#define APP_TIMER_CONFIG_USE_SCHEDULER 0
+#endif
+
+// <q> APP_TIMER_KEEPS_RTC_ACTIVE  - Enable RTC always on
+
+// <i> If option is enabled RTC is kept running even if there is no active timers.
+// <i> This option can be used when app_timer is used for timestamping.
+
+#ifndef APP_TIMER_KEEPS_RTC_ACTIVE
+#define APP_TIMER_KEEPS_RTC_ACTIVE 0
+#endif
+
+// <o> APP_TIMER_SAFE_WINDOW_MS - Maximum possible latency (in milliseconds) of handling app_timer event.
+// <i> Maximum possible timeout that can be set is reduced by safe window.
+// <i> Example: RTC frequency 16384 Hz, maximum possible timeout 1024 seconds - APP_TIMER_SAFE_WINDOW_MS.
+// <i> Since RTC is not stopped when processor is halted in debugging session, this value
+// <i> must cover it if debugging is needed. It is possible to halt processor for APP_TIMER_SAFE_WINDOW_MS
+// <i> without corrupting app_timer behavior.
+
+#ifndef APP_TIMER_SAFE_WINDOW_MS
+#define APP_TIMER_SAFE_WINDOW_MS 300000
+#endif
+
+// <h> App Timer Legacy configuration - Legacy configuration.
+
+//==========================================================
+// <q> APP_TIMER_WITH_PROFILER  - Enable app_timer profiling
+
+#ifndef APP_TIMER_WITH_PROFILER
+#define APP_TIMER_WITH_PROFILER 0
+#endif
+
+// <q> APP_TIMER_CONFIG_SWI_NUMBER  - Configure SWI instance used.
+
+#ifndef APP_TIMER_CONFIG_SWI_NUMBER
+#define APP_TIMER_CONFIG_SWI_NUMBER 0
+#endif
+
+//---
+
+// <e> PEER_MANAGER_ENABLED - peer_manager - Peer Manager
+//==========================================================
+#ifndef PEER_MANAGER_ENABLED
+#define PEER_MANAGER_ENABLED 1
+#endif
+// <o> PM_MAX_REGISTRANTS - Number of event handlers that can be registered.
+#ifndef PM_MAX_REGISTRANTS
+#define PM_MAX_REGISTRANTS 3
+#endif
+
+// <o> PM_FLASH_BUFFERS - Number of internal buffers for flash operations.
+// <i> Decrease this value to lower RAM usage.
+
+#ifndef PM_FLASH_BUFFERS
+#define PM_FLASH_BUFFERS 4
+#endif
+
+// <q> PM_CENTRAL_ENABLED  - Enable/disable central-specific Peer Manager functionality.
+
+// <i> Enable/disable central-specific Peer Manager functionality.
+
+#ifndef PM_CENTRAL_ENABLED
+#define PM_CENTRAL_ENABLED 0
+#endif
+
+// <q> PM_SERVICE_CHANGED_ENABLED  - Enable/disable the service changed management for GATT server in Peer Manager.
+
+// <i> If not using a GATT server, or using a server wihout a service changed characteristic,
+// <i> disable this to save code space.
+
+#ifndef PM_SERVICE_CHANGED_ENABLED
+#define PM_SERVICE_CHANGED_ENABLED 1
+#endif
+
+// <q> PM_PEER_RANKS_ENABLED  - Enable/disable the peer rank management in Peer Manager.
+
+// <i> Set this to false to save code space if not using the peer rank API.
+
+#ifndef PM_PEER_RANKS_ENABLED
+#define PM_PEER_RANKS_ENABLED 1
+#endif
+
+// <q> PM_LESC_ENABLED  - Enable/disable LESC support in Peer Manager.
+
+// <i> If set to true, you need to call nrf_ble_lesc_request_handler() in the main loop to respond to LESC-related BLE events. If LESC support is not required, set this to false to save code space.
+
+#ifndef PM_LESC_ENABLED
+#define PM_LESC_ENABLED 0
+#endif
+
+// <e> PM_RA_PROTECTION_ENABLED - Enable/disable protection against repeated pairing attempts in Peer Manager.
+//==========================================================
+#ifndef PM_RA_PROTECTION_ENABLED
+#define PM_RA_PROTECTION_ENABLED 1
+#endif
+// <o> PM_RA_PROTECTION_TRACKED_PEERS_NUM - Maximum number of peers whose authorization status can be tracked.
+#ifndef PM_RA_PROTECTION_TRACKED_PEERS_NUM
+#define PM_RA_PROTECTION_TRACKED_PEERS_NUM 8
+#endif
+
+// <o> PM_RA_PROTECTION_MIN_WAIT_INTERVAL - Minimum waiting interval (in ms) before a new pairing attempt can be initiated.
+#ifndef PM_RA_PROTECTION_MIN_WAIT_INTERVAL
+#define PM_RA_PROTECTION_MIN_WAIT_INTERVAL 4000
+#endif
+
+// <o> PM_RA_PROTECTION_MAX_WAIT_INTERVAL - Maximum waiting interval (in ms) before a new pairing attempt can be initiated.
+#ifndef PM_RA_PROTECTION_MAX_WAIT_INTERVAL
+#define PM_RA_PROTECTION_MAX_WAIT_INTERVAL 64000
+#endif
+
+// <o> PM_RA_PROTECTION_REWARD_PERIOD - Reward period (in ms).
+// <i> The waiting interval is gradually decreased when no new failed pairing attempts are made during reward period.
+
+#ifndef PM_RA_PROTECTION_REWARD_PERIOD
+#define PM_RA_PROTECTION_REWARD_PERIOD 10000
+#endif
+
+// </e>
+
+// <o> PM_HANDLER_SEC_DELAY_MS - Delay before starting security.
+// <i>  This might be necessary for interoperability reasons, especially as peripheral.
+
+#ifndef PM_HANDLER_SEC_DELAY_MS
+#define PM_HANDLER_SEC_DELAY_MS 0
+#endif
+
+// </e>
+
+// <e> NRF_BLE_GQ_ENABLED - nrf_ble_gq - BLE GATT Queue Module
+//==========================================================
+#ifndef NRF_BLE_GQ_ENABLED
+#define NRF_BLE_GQ_ENABLED 1
+#endif
+// <o> NRF_BLE_GQ_DATAPOOL_ELEMENT_SIZE - Default size of a single element in the pool of memory objects.
+#ifndef NRF_BLE_GQ_DATAPOOL_ELEMENT_SIZE
+#define NRF_BLE_GQ_DATAPOOL_ELEMENT_SIZE 20
+#endif
+
+// <o> NRF_BLE_GQ_DATAPOOL_ELEMENT_COUNT - Default number of elements in the pool of memory objects.
+#ifndef NRF_BLE_GQ_DATAPOOL_ELEMENT_COUNT
+#define NRF_BLE_GQ_DATAPOOL_ELEMENT_COUNT 8
+#endif
+
+// <o> NRF_BLE_GQ_GATTC_WRITE_MAX_DATA_LEN - Maximal size of the data inside GATTC write request (in bytes).
+#ifndef NRF_BLE_GQ_GATTC_WRITE_MAX_DATA_LEN
+#define NRF_BLE_GQ_GATTC_WRITE_MAX_DATA_LEN 16
+#endif
+
+// <o> NRF_BLE_GQ_GATTS_HVX_MAX_DATA_LEN - Maximal size of the data inside GATTC notification or indication request (in bytes).
+#ifndef NRF_BLE_GQ_GATTS_HVX_MAX_DATA_LEN
+#define NRF_BLE_GQ_GATTS_HVX_MAX_DATA_LEN 16
+#endif
+
+// <e> NRF_BALLOC_ENABLED - nrf_balloc - Block allocator module
+//==========================================================
+#ifndef NRF_BALLOC_ENABLED
+#define NRF_BALLOC_ENABLED 1
+#endif
+// <e> NRF_BALLOC_CONFIG_DEBUG_ENABLED - Enables debug mode in the module.
+//==========================================================
+#ifndef NRF_BALLOC_CONFIG_DEBUG_ENABLED
+#define NRF_BALLOC_CONFIG_DEBUG_ENABLED 0
+#endif
+// <o> NRF_BALLOC_CONFIG_HEAD_GUARD_WORDS - Number of words used as head guard.  <0-255>
+
+#ifndef NRF_BALLOC_CONFIG_HEAD_GUARD_WORDS
+#define NRF_BALLOC_CONFIG_HEAD_GUARD_WORDS 1
+#endif
+
+// <o> NRF_BALLOC_CONFIG_TAIL_GUARD_WORDS - Number of words used as tail guard.  <0-255>
+
+#ifndef NRF_BALLOC_CONFIG_TAIL_GUARD_WORDS
+#define NRF_BALLOC_CONFIG_TAIL_GUARD_WORDS 1
+#endif
+
+// <q> NRF_BALLOC_CONFIG_BASIC_CHECKS_ENABLED  - Enables basic checks in this module.
+
+#ifndef NRF_BALLOC_CONFIG_BASIC_CHECKS_ENABLED
+#define NRF_BALLOC_CONFIG_BASIC_CHECKS_ENABLED 0
+#endif
+
+// <q> NRF_BALLOC_CONFIG_DOUBLE_FREE_CHECK_ENABLED  - Enables double memory free check in this module.
+
+#ifndef NRF_BALLOC_CONFIG_DOUBLE_FREE_CHECK_ENABLED
+#define NRF_BALLOC_CONFIG_DOUBLE_FREE_CHECK_ENABLED 0
+#endif
+
+// <q> NRF_BALLOC_CONFIG_DATA_TRASHING_CHECK_ENABLED  - Enables free memory corruption check in this module.
+
+#ifndef NRF_BALLOC_CONFIG_DATA_TRASHING_CHECK_ENABLED
+#define NRF_BALLOC_CONFIG_DATA_TRASHING_CHECK_ENABLED 0
+#endif
+
+// <q> NRF_BALLOC_CLI_CMDS  - Enable CLI commands specific to the module
+
+#ifndef NRF_BALLOC_CLI_CMDS
+#define NRF_BALLOC_CLI_CMDS 0
+#endif
+
+// </e>
+
+// </e>
+
+// <e> NRF_QUEUE_ENABLED - nrf_queue - Queue module
+//==========================================================
+#ifndef NRF_QUEUE_ENABLED
+#define NRF_QUEUE_ENABLED 1
+#endif
+
+#endif // SDK_CONFIG_H

--- a/ci/libraries_tests/nrf5_ble_srv_tps/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ble_srv_tps/CMakeLists.txt
@@ -1,0 +1,51 @@
+# MIT License
+
+# Copyright (c) 2020 Polidea
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# WARNING: FILE GENERATED FROM ./ci/scripts/generate_cmake_tests.sh SCRIPT.
+
+cmake_minimum_required(VERSION 3.14)
+project(nrf5_ble_srv_tps_test LANGUAGES C ASM)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../../cmake")
+include("nrf5")
+
+add_executable(${CMAKE_PROJECT_NAME} "main.c")
+nrf5_target(${CMAKE_PROJECT_NAME})
+target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_srv_tps
+  nrf5_config
+  nrf5_delay
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)

--- a/ci/libraries_tests/nrf5_ble_srv_tps/main.c
+++ b/ci/libraries_tests/nrf5_ble_srv_tps/main.c
@@ -1,0 +1,13 @@
+#include "ble_tps.h"
+
+void app_error_handler_bare(uint32_t error_code)
+{
+}
+
+int main()
+{
+    ble_tps_t tps;
+    ble_tps_init_t tps_init;
+    ble_tps_init(&tps, &tps_init);
+    return 0;
+}

--- a/ci/libraries_tests/nrf5_ble_srv_tps/sdk_config.h
+++ b/ci/libraries_tests/nrf5_ble_srv_tps/sdk_config.h
@@ -1,0 +1,233 @@
+#ifndef SDK_CONFIG_H
+#define SDK_CONFIG_H
+
+#ifndef NRF_LOG_ENABLED
+#define NRF_LOG_ENABLED 0
+#endif
+
+// </h>
+//==========================================================
+
+// </h>
+//==========================================================
+
+// <h> nRF_SoftDevice
+
+//==========================================================
+// <e> NRF_SDH_BLE_ENABLED - nrf_sdh_ble - SoftDevice BLE event handler
+//==========================================================
+#ifndef NRF_SDH_BLE_ENABLED
+#define NRF_SDH_BLE_ENABLED 1
+#endif
+// <h> BLE Stack configuration - Stack configuration parameters
+
+// <i> The SoftDevice handler will configure the stack with these parameters when calling @ref nrf_sdh_ble_default_cfg_set.
+// <i> Other libraries might depend on these values; keep them up-to-date even if you are not explicitely calling @ref nrf_sdh_ble_default_cfg_set.
+//==========================================================
+// <o> NRF_SDH_BLE_GAP_DATA_LENGTH   <27-251>
+
+// <i> Requested BLE GAP data length to be negotiated.
+
+#ifndef NRF_SDH_BLE_GAP_DATA_LENGTH
+#define NRF_SDH_BLE_GAP_DATA_LENGTH 27
+#endif
+
+// <o> NRF_SDH_BLE_PERIPHERAL_LINK_COUNT - Maximum number of peripheral links.
+#ifndef NRF_SDH_BLE_PERIPHERAL_LINK_COUNT
+#define NRF_SDH_BLE_PERIPHERAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_CENTRAL_LINK_COUNT - Maximum number of central links.
+#ifndef NRF_SDH_BLE_CENTRAL_LINK_COUNT
+#define NRF_SDH_BLE_CENTRAL_LINK_COUNT 0
+#endif
+
+// <o> NRF_SDH_BLE_TOTAL_LINK_COUNT - Total link count.
+// <i> Maximum number of total concurrent connections using the default configuration.
+
+#ifndef NRF_SDH_BLE_TOTAL_LINK_COUNT
+#define NRF_SDH_BLE_TOTAL_LINK_COUNT 1
+#endif
+
+// <o> NRF_SDH_BLE_GAP_EVENT_LENGTH - GAP event length.
+// <i> The time set aside for this connection on every connection interval in 1.25 ms units.
+
+#ifndef NRF_SDH_BLE_GAP_EVENT_LENGTH
+#define NRF_SDH_BLE_GAP_EVENT_LENGTH 6
+#endif
+
+// <o> NRF_SDH_BLE_GATT_MAX_MTU_SIZE - Static maximum MTU size.
+#ifndef NRF_SDH_BLE_GATT_MAX_MTU_SIZE
+#define NRF_SDH_BLE_GATT_MAX_MTU_SIZE 23
+#endif
+
+// <o> NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE - Attribute Table size in bytes. The size must be a multiple of 4.
+#ifndef NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE
+#define NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE 1408
+#endif
+
+// <o> NRF_SDH_BLE_VS_UUID_COUNT - The number of vendor-specific UUIDs.
+#ifndef NRF_SDH_BLE_VS_UUID_COUNT
+#define NRF_SDH_BLE_VS_UUID_COUNT 0
+#endif
+
+// <q> NRF_SDH_BLE_SERVICE_CHANGED  - Include the Service Changed characteristic in the Attribute Table.
+
+#ifndef NRF_SDH_BLE_SERVICE_CHANGED
+#define NRF_SDH_BLE_SERVICE_CHANGED 0
+#endif
+
+// <e> NRF_SDH_SOC_ENABLED - nrf_sdh_soc - SoftDevice SoC event handler
+//==========================================================
+#ifndef NRF_SDH_SOC_ENABLED
+#define NRF_SDH_SOC_ENABLED 1
+#endif
+// <h> SoC Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_SOC_OBSERVER_PRIO_LEVELS - Total number of priority levels for SoC observers.
+// <i> This setting configures the number of priority levels available for the SoC event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_SOC_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_SOC_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <h> SoC Observers priorities - Invididual priorities
+
+// <e> NRF_SDH_ENABLED - nrf_sdh - SoftDevice handler
+//==========================================================
+#ifndef NRF_SDH_ENABLED
+#define NRF_SDH_ENABLED 1
+#endif
+
+// </h>
+//==========================================================
+
+// <h> Clock - SoftDevice clock configuration
+
+//==========================================================
+// <o> NRF_SDH_CLOCK_LF_SRC  - SoftDevice clock source.
+
+// <0=> NRF_CLOCK_LF_SRC_RC
+// <1=> NRF_CLOCK_LF_SRC_XTAL
+// <2=> NRF_CLOCK_LF_SRC_SYNTH
+
+#ifndef NRF_SDH_CLOCK_LF_SRC
+#define NRF_SDH_CLOCK_LF_SRC 1
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_CTIV - SoftDevice calibration timer interval.
+#ifndef NRF_SDH_CLOCK_LF_RC_CTIV
+#define NRF_SDH_CLOCK_LF_RC_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_RC_TEMP_CTIV - SoftDevice calibration timer interval under constant temperature.
+// <i> How often (in number of calibration intervals) the RC oscillator shall be calibrated
+// <i>  if the temperature has not changed.
+
+#ifndef NRF_SDH_CLOCK_LF_RC_TEMP_CTIV
+#define NRF_SDH_CLOCK_LF_RC_TEMP_CTIV 0
+#endif
+
+// <o> NRF_SDH_CLOCK_LF_ACCURACY  - External clock accuracy used in the LL to compute timing.
+
+// <0=> NRF_CLOCK_LF_ACCURACY_250_PPM
+// <1=> NRF_CLOCK_LF_ACCURACY_500_PPM
+// <2=> NRF_CLOCK_LF_ACCURACY_150_PPM
+// <3=> NRF_CLOCK_LF_ACCURACY_100_PPM
+// <4=> NRF_CLOCK_LF_ACCURACY_75_PPM
+// <5=> NRF_CLOCK_LF_ACCURACY_50_PPM
+// <6=> NRF_CLOCK_LF_ACCURACY_30_PPM
+// <7=> NRF_CLOCK_LF_ACCURACY_20_PPM
+// <8=> NRF_CLOCK_LF_ACCURACY_10_PPM
+// <9=> NRF_CLOCK_LF_ACCURACY_5_PPM
+// <10=> NRF_CLOCK_LF_ACCURACY_2_PPM
+// <11=> NRF_CLOCK_LF_ACCURACY_1_PPM
+
+#ifndef NRF_SDH_CLOCK_LF_ACCURACY
+#define NRF_SDH_CLOCK_LF_ACCURACY 7
+#endif
+
+// <o> NRF_SDH_SOC_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which SoC events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have SoC events dispatched before or after other stack events, such as ANT or BLE.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_SOC_STACK_OBSERVER_PRIO
+#define NRF_SDH_SOC_STACK_OBSERVER_PRIO 0
+#endif
+
+// </h>
+//==========================================================
+
+// <h> BLE Observers - Observers and priority levels
+
+//==========================================================
+// <o> NRF_SDH_BLE_OBSERVER_PRIO_LEVELS - Total number of priority levels for BLE observers.
+// <i> This setting configures the number of priority levels available for BLE event handlers.
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_BLE_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_BLE_OBSERVER_PRIO_LEVELS 4
+#endif
+
+// <h> BLE Observers priorities - Invididual priorities
+
+//==========================================================
+// <o> BLE_ADV_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Advertising module.
+
+#ifndef BLE_ADV_BLE_OBSERVER_PRIO
+#define BLE_ADV_BLE_OBSERVER_PRIO 1
+#endif
+
+// <o> BLE_CONN_STATE_BLE_OBSERVER_PRIO
+// <i> Priority with which BLE events are dispatched to the Connection State module.
+
+#ifndef BLE_CONN_STATE_BLE_OBSERVER_PRIO
+#define BLE_CONN_STATE_BLE_OBSERVER_PRIO 0
+#endif
+
+// <o> NRF_SDH_STACK_OBSERVER_PRIO_LEVELS - Total number of priority levels for stack event observers.
+// <i> This setting configures the number of priority levels available for the SoftDevice stack event handlers (ANT, BLE, SoC).
+// <i> The priority level of a handler determines the order in which it receives events, with respect to other handlers.
+
+#ifndef NRF_SDH_STACK_OBSERVER_PRIO_LEVELS
+#define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
+#endif
+
+// <o> NRF_SDH_BLE_STACK_OBSERVER_PRIO
+// <i> This setting configures the priority with which BLE events are processed with respect to other events coming from the stack.
+// <i> Modify this setting if you need to have BLE events dispatched before or after other stack events, such as ANT or SoC.
+// <i> Zero is the highest priority.
+
+#ifndef NRF_SDH_BLE_STACK_OBSERVER_PRIO
+#define NRF_SDH_BLE_STACK_OBSERVER_PRIO 0
+#endif
+
+//---
+
+// <e> NRF_BLE_QWR_ENABLED - nrf_ble_qwr - Queued writes support module (prepare/execute write)
+//==========================================================
+#ifndef NRF_BLE_QWR_ENABLED
+#define NRF_BLE_QWR_ENABLED 1
+#endif
+// <o> NRF_BLE_QWR_MAX_ATTR - Maximum number of attribute handles that can be registered. This number must be adjusted according to the number of attributes for which Queued Writes will be enabled. If it is zero, the module will reject all Queued Write requests.
+#ifndef NRF_BLE_QWR_MAX_ATTR
+#define NRF_BLE_QWR_MAX_ATTR 1
+#endif
+
+// <q> NRF_SECTION_ITER_ENABLED  - nrf_section_iter - Section iterator
+
+#ifndef NRF_SECTION_ITER_ENABLED
+#define NRF_SECTION_ITER_ENABLED 1
+#endif
+
+//---
+
+#ifndef BLE_TPS_ENABLED
+#define BLE_TPS_ENABLED 1
+#endif
+
+#endif // SDK_CONFIG_H

--- a/ci/libraries_tests/nrf5_block_dev_empty/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_block_dev_empty/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_block_dev_qspi/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_block_dev_qspi/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_block_dev_ram/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_block_dev_ram/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_block_dev_sdc/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_block_dev_sdc/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_sdcard
   nrf5_app_util_platform
   nrf5_atfifo
@@ -57,6 +58,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_mtx
   nrf5_nrfx_common
   nrf5_nrfx_hal
+  nrf5_nrfx_spi
   nrf5_nrfx_spim
   nrf5_pwr_mgmt
   nrf5_queue

--- a/ci/libraries_tests/nrf5_block_dev_sdc/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_block_dev_sdc/CMakeLists.txt
@@ -58,6 +58,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_mtx
   nrf5_nrfx_common
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_nrfx_spi
   nrf5_nrfx_spim
   nrf5_pwr_mgmt

--- a/ci/libraries_tests/nrf5_bsp/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_bsp/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_bsp_btn_ble/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_bsp_btn_ble/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_bsp_cli/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_bsp_cli/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_cli_cdc_acm/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_cli_cdc_acm/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli_cdc_acm
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_clock
   nrf5_drv_power

--- a/ci/libraries_tests/nrf5_cli_uart/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_cli_uart/CMakeLists.txt
@@ -56,6 +56,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_mtx
   nrf5_nrfx_common
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_nrfx_uart
   nrf5_nrfx_uarte
   nrf5_pwr_mgmt

--- a/ci/libraries_tests/nrf5_cli_uart/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_cli_uart/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli_fwd
   nrf5_cli_uart
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_uart
   nrf5_ext_fprintf

--- a/ci/libraries_tests/nrf5_crypto/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_crypto/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_crypto
   nrf5_delay
   nrf5_ext_cc310_bl_fwd

--- a/ci/libraries_tests/nrf5_crypto_cc310_backend/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_crypto_cc310_backend/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_crypto
   nrf5_crypto_cc310_backend
   nrf5_delay

--- a/ci/libraries_tests/nrf5_crypto_cc310_bl_backend/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_crypto_cc310_bl_backend/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_crypto
   nrf5_crypto_cc310_bl_backend
   nrf5_delay

--- a/ci/libraries_tests/nrf5_crypto_cifra_backend/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_crypto_cifra_backend/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_crypto
   nrf5_crypto_cifra_backend
   nrf5_delay

--- a/ci/libraries_tests/nrf5_crypto_mbedtls_backend/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_crypto_mbedtls_backend/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_crypto
   nrf5_crypto_mbedtls_backend
   nrf5_delay

--- a/ci/libraries_tests/nrf5_crypto_micro_ecc_backend/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_crypto_micro_ecc_backend/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_crypto
   nrf5_crypto_micro_ecc_backend
   nrf5_delay

--- a/ci/libraries_tests/nrf5_crypto_nrf_hw_backend/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_crypto_nrf_hw_backend/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_crypto
   nrf5_crypto_nrf_hw_backend
   nrf5_delay

--- a/ci/libraries_tests/nrf5_crypto_nrf_sw_backend/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_crypto_nrf_sw_backend/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_crypto
   nrf5_crypto_nrf_sw_backend
   nrf5_delay

--- a/ci/libraries_tests/nrf5_crypto_oberon_backend/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_crypto_oberon_backend/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_crypto
   nrf5_crypto_oberon_backend
   nrf5_delay

--- a/ci/libraries_tests/nrf5_crypto_optiga_backend/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_crypto_optiga_backend/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_crypto
   nrf5_crypto_optiga_backend
   nrf5_delay

--- a/ci/libraries_tests/nrf5_drv_clock/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_drv_clock/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_clock
   nrf5_ext_fprintf

--- a/ci/libraries_tests/nrf5_drv_power/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_drv_power/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_power
   nrf5_ext_fprintf

--- a/ci/libraries_tests/nrf5_drv_ppi/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_drv_ppi/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_drv_rng/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_drv_rng/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_rng
   nrf5_ext_fprintf

--- a/ci/libraries_tests/nrf5_drv_spi/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_drv_spi/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_spi
   nrf5_ext_fprintf

--- a/ci/libraries_tests/nrf5_drv_spis/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_drv_spis/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_spis
   nrf5_ext_fprintf

--- a/ci/libraries_tests/nrf5_drv_twi/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_drv_twi/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_twi
   nrf5_ext_fprintf

--- a/ci/libraries_tests/nrf5_drv_uart/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_drv_uart/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_uart
   nrf5_ext_fprintf

--- a/ci/libraries_tests/nrf5_drv_uart/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_drv_uart/CMakeLists.txt
@@ -54,6 +54,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_mtx
   nrf5_nrfx_common
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_nrfx_uart
   nrf5_nrfx_uarte
   nrf5_pwr_mgmt

--- a/ci/libraries_tests/nrf5_ext_fatfs/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ext_fatfs/CMakeLists.txt
@@ -32,5 +32,4 @@ add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_ext_fatfs
-  nrf5_ext_fatfs_port_diskio_blkdev
 )

--- a/ci/libraries_tests/nrf5_ext_fatfs/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ext_fatfs/CMakeLists.txt
@@ -21,6 +21,8 @@
 # SOFTWARE.
 #
 # WARNING: FILE GENERATED FROM ./ci/scripts/generate_cmake_tests.sh SCRIPT.
+# WARNING: This test contains custom patch to allow compilation. Please edit
+#          above script if there is a need to do it.
 
 cmake_minimum_required(VERSION 3.14)
 project(nrf5_ext_fatfs_test LANGUAGES C ASM)
@@ -31,5 +33,10 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_block_dev
+  nrf5_config
   nrf5_ext_fatfs
+  nrf5_ext_fatfs_port_diskio_blkdev
+  nrf5_mdk
+  nrf5_soc
 )

--- a/ci/libraries_tests/nrf5_ext_optiga/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_ext_optiga/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_rtc
   nrf5_drv_twi

--- a/ci/libraries_tests/nrf5_fds/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_fds/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_atfifo
   nrf5_atomic
   nrf5_config
+  nrf5_crc16
   nrf5_fds
   nrf5_fstorage
   nrf5_fstorage_sd

--- a/ci/libraries_tests/nrf5_gfx/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_gfx/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_hardfault/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_hardfault/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_led_softblink/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_led_softblink/CMakeLists.txt
@@ -42,5 +42,4 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_nrfx_common
   nrf5_nrfx_hal
   nrf5_soc
-  nrf5_app_error
 )

--- a/ci/libraries_tests/nrf5_led_softblink/main.c
+++ b/ci/libraries_tests/nrf5_led_softblink/main.c
@@ -1,5 +1,9 @@
 #include "led_softblink.h"
 
+void app_error_handler_bare(uint32_t error_code)
+{
+}
+
 int main()
 {
     led_sb_init_params_t init_params = LED_SB_INIT_DEFAULT_PARAMS(0);

--- a/ci/libraries_tests/nrf5_log/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_log/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_log_backend_flash/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_log_backend_flash/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_log_backend_rtt/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_log_backend_rtt/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_ext_segger_rtt

--- a/ci/libraries_tests/nrf5_log_backend_serial/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_log_backend_serial/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_log_backend_uart/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_log_backend_uart/CMakeLists.txt
@@ -55,6 +55,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_mtx
   nrf5_nrfx_common
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_nrfx_uart
   nrf5_nrfx_uarte
   nrf5_pwr_mgmt

--- a/ci/libraries_tests/nrf5_log_backend_uart/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_log_backend_uart/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_uart
   nrf5_ext_fprintf

--- a/ci/libraries_tests/nrf5_log_default_backends/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_log_default_backends/CMakeLists.txt
@@ -59,6 +59,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_mtx
   nrf5_nrfx_common
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_nrfx_uart
   nrf5_nrfx_uarte
   nrf5_pwr_mgmt

--- a/ci/libraries_tests/nrf5_log_default_backends/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_log_default_backends/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_uart
   nrf5_ext_fprintf

--- a/ci/libraries_tests/nrf5_low_power_pwm/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_low_power_pwm/CMakeLists.txt
@@ -41,5 +41,4 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_nrfx_common
   nrf5_nrfx_hal
   nrf5_soc
-  nrf5_app_error
 )

--- a/ci/libraries_tests/nrf5_low_power_pwm/main.c
+++ b/ci/libraries_tests/nrf5_low_power_pwm/main.c
@@ -1,5 +1,9 @@
 #include "low_power_pwm.h"
 
+void app_error_handler_bare(uint32_t error_code)
+{
+}
+
 int main()
 {
     low_power_pwm_init(NULL, NULL, NULL);

--- a/ci/libraries_tests/nrf5_mpu/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_mpu/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_nrfx_clock/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_clock/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_nrfx_comp/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_comp/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -60,5 +61,4 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_section
   nrf5_soc
   nrf5_strerror
-  nrf5_nrfx_prs
 )

--- a/ci/libraries_tests/nrf5_nrfx_comp/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_comp/CMakeLists.txt
@@ -54,6 +54,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_nrfx_common
   nrf5_nrfx_comp
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_pwr_mgmt
   nrf5_queue
   nrf5_ringbuf

--- a/ci/libraries_tests/nrf5_nrfx_gpiote/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_gpiote/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_nrfx_i2s/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_i2s/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_nrfx_lpcomp/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_lpcomp/CMakeLists.txt
@@ -54,6 +54,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_nrfx_common
   nrf5_nrfx_hal
   nrf5_nrfx_lpcomp
+  nrf5_nrfx_prs
   nrf5_pwr_mgmt
   nrf5_queue
   nrf5_ringbuf

--- a/ci/libraries_tests/nrf5_nrfx_lpcomp/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_lpcomp/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic
@@ -60,5 +61,4 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_section
   nrf5_soc
   nrf5_strerror
-  nrf5_nrfx_prs
 )

--- a/ci/libraries_tests/nrf5_nrfx_power/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_power/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_nrfx_ppi/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_ppi/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_nrfx_prs/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_prs/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_nrfx_pwm/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_pwm/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_nrfx_qdec/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_qdec/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_nrfx_qspi/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_qspi/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_nrfx_rng/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_rng/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_nrfx_rtc/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_rtc/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_nrfx_saadc/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_saadc/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_nrfx_spi/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_spi/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_nrfx_spim/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_spim/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_nrfx_spis/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_spis/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_nrfx_systick/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_systick/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_nrfx_timer/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_timer/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_nrfx_twi/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_twi/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_nrfx_twim/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_twim/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_nrfx_uart/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_uart/CMakeLists.txt
@@ -53,6 +53,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_mtx
   nrf5_nrfx_common
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_nrfx_uart
   nrf5_pwr_mgmt
   nrf5_queue

--- a/ci/libraries_tests/nrf5_nrfx_uart/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_uart/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_nrfx_uarte/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_uarte/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_nrfx_uarte/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_uarte/CMakeLists.txt
@@ -53,6 +53,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_mtx
   nrf5_nrfx_common
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_nrfx_uarte
   nrf5_pwr_mgmt
   nrf5_queue

--- a/ci/libraries_tests/nrf5_nrfx_usbd/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_usbd/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_nrfx_wdt/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_nrfx_wdt/CMakeLists.txt
@@ -31,6 +31,7 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME} "main.c")
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
+  nrf5_app_scheduler
   nrf5_app_util_platform
   nrf5_atfifo
   nrf5_atomic

--- a/ci/libraries_tests/nrf5_serial/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_serial/CMakeLists.txt
@@ -55,6 +55,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_mtx
   nrf5_nrfx_common
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_nrfx_uart
   nrf5_nrfx_uarte
   nrf5_pwr_mgmt

--- a/ci/libraries_tests/nrf5_serial/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_serial/CMakeLists.txt
@@ -65,5 +65,4 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_serial
   nrf5_soc
   nrf5_strerror
-  nrf5_nrfx_prs
 )

--- a/ci/libraries_tests/nrf5_sortlist/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_sortlist/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_spi_mngr/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_spi_mngr/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_spi
   nrf5_ext_fprintf

--- a/ci/libraries_tests/nrf5_stack_guard/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_stack_guard/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_ext_fprintf
   nrf5_fds

--- a/ci/libraries_tests/nrf5_twi_mngr/CMakeLists.txt
+++ b/ci/libraries_tests/nrf5_twi_mngr/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC
   nrf5_cli
   nrf5_cli_fwd
   nrf5_config
+  nrf5_crc16
   nrf5_delay
   nrf5_drv_twi
   nrf5_ext_fprintf

--- a/ci/scripts/python/generate_cmake_tests.py
+++ b/ci/scripts/python/generate_cmake_tests.py
@@ -25,6 +25,7 @@ def generate_library_test(library_name: str, library: LibraryDescription, librar
     custom_patches = {
         "nrf5_ble_lesc": {"nrf5_crypto_cc310_backend"},
         "nrf5_fds": {"nrf5_fstorage_sd"},
+        "nrf5_ext_fatfs": {"nrf5_ext_fatfs_port_diskio_blkdev"},
         "nrf5_ble_peer_data_storage": {"nrf5_ble_peer_manager"},
         "nrf5_ble_peer_manager": {"nrf5_fstorage_sd"},
         "nrf5_ble_srv_ots": {"nrf5_fstorage_sd"},

--- a/ci/scripts/python/generate_cmake_tests.py
+++ b/ci/scripts/python/generate_cmake_tests.py
@@ -27,6 +27,8 @@ def generate_library_test(library_name: str, library: LibraryDescription, librar
         "nrf5_fds": {"nrf5_fstorage_sd"},
         "nrf5_ble_peer_data_storage": {"nrf5_ble_peer_manager"},
         "nrf5_ble_peer_manager": {"nrf5_fstorage_sd"},
+        "nrf5_ble_srv_ots": {"nrf5_fstorage_sd"},
+        "nrf5_ble_srv_eddystone": {"nrf5_fstorage_sd"},
         "nrf5_log_default_backends": {
             "nrf5_log_backend_uart",
             "nrf5_log_backend_serial"

--- a/cmake/nrf5_app.cmake
+++ b/cmake/nrf5_app.cmake
@@ -232,6 +232,7 @@ list(APPEND NRF5_LIBRARY_NRF5_APP_UART_DEPENDENCIES
   nrf5_mtx
   nrf5_nrfx_common
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_nrfx_uart
   nrf5_nrfx_uarte
   nrf5_pwr_mgmt
@@ -281,6 +282,7 @@ list(APPEND NRF5_LIBRARY_NRF5_APP_UART_FIFO_DEPENDENCIES
   nrf5_mtx
   nrf5_nrfx_common
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_nrfx_uart
   nrf5_nrfx_uarte
   nrf5_pwr_mgmt
@@ -406,6 +408,7 @@ target_include_directories(nrf5_app_sdcard PUBLIC
 target_link_libraries(nrf5_app_sdcard PUBLIC
   nrf5_drv_spi
   nrf5_ext_protothreads
+  nrf5_nrfx_prs
 )
 list(APPEND NRF5_LIBRARY_NRF5_APP_SDCARD_DEPENDENCIES
   nrf5_app_scheduler
@@ -433,6 +436,7 @@ list(APPEND NRF5_LIBRARY_NRF5_APP_SDCARD_DEPENDENCIES
   nrf5_mtx
   nrf5_nrfx_common
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_nrfx_spi
   nrf5_nrfx_spim
   nrf5_pwr_mgmt

--- a/cmake/nrf5_ble.cmake
+++ b/cmake/nrf5_ble.cmake
@@ -363,3 +363,23 @@ if(NRF5_SDK_VERSION VERSION_GREATER_EQUAL 16.0.0)
     )
   endif()
 endif()
+
+# BLE Record Access Control Point library
+add_library(nrf5_ble_racp OBJECT EXCLUDE_FROM_ALL
+  "${NRF5_SDK_PATH}/components/ble/ble_racp/ble_racp.c"
+)
+target_include_directories(nrf5_ble_racp PUBLIC
+  "${NRF5_SDK_PATH}/components/ble/ble_racp"
+  "${NRF5_SDK_PATH}/components/libraries/util"
+)
+target_link_libraries(nrf5_ble_racp PUBLIC
+  nrf5_config
+  nrf5_mdk
+  nrf5_soc
+)
+list(APPEND NRF5_LIBRARY_NRF5_BLE_RACP_DEPENDENCIES
+  nrf5_ble_racp
+  nrf5_config
+  nrf5_mdk
+  nrf5_soc
+)

--- a/cmake/nrf5_ble_srv.cmake
+++ b/cmake/nrf5_ble_srv.cmake
@@ -319,6 +319,38 @@ list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_LLS_DEPENDENCIES
   nrf5_strerror
 )
 
+# BLE Immediate Alert Service Client (Peripheral)
+add_library(nrf5_ble_srv_ias OBJECT EXCLUDE_FROM_ALL
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_ias/ble_ias.c"
+)
+target_include_directories(nrf5_ble_srv_ias PUBLIC
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_ias"
+)
+target_link_libraries(nrf5_ble_srv_ias PUBLIC
+  nrf5_ble_common
+  nrf5_ble_link_ctx_manager
+)
+list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_IAS_DEPENDENCIES
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_link_ctx_manager
+  nrf5_ble_srv_ias
+  nrf5_config
+  nrf5_delay
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+
 # BLE Immediate Alert Service Client (Central)
 add_library(nrf5_ble_srv_ias_c OBJECT EXCLUDE_FROM_ALL
   "${NRF5_SDK_PATH}/components/ble/ble_services/ble_ias_c/ble_ias_c.c"
@@ -841,5 +873,362 @@ list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_HRS_DEPENDENCIES
   nrf5_sdh
   nrf5_section
   nrf5_soc
+  nrf5_strerror
+)
+
+# BLE TX Power Service
+add_library(nrf5_ble_srv_tps OBJECT EXCLUDE_FROM_ALL
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_tps/ble_tps.c"
+)
+target_include_directories(nrf5_ble_srv_tps PUBLIC
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_tps"
+)
+target_link_libraries(nrf5_ble_srv_tps PUBLIC
+  nrf5_ble_common
+)
+list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_TPS_DEPENDENCIES
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_srv_tps
+  nrf5_config
+  nrf5_delay
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+
+# BLE Glucose Service
+add_library(nrf5_ble_srv_gls OBJECT EXCLUDE_FROM_ALL
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_gls/ble_gls.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_gls/ble_gls_db.c"
+)
+target_include_directories(nrf5_ble_srv_gls PUBLIC
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_gls"
+)
+target_link_libraries(nrf5_ble_srv_gls PUBLIC
+  nrf5_ble_common
+  nrf5_ble_racp
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  
+  target_link_libraries(nrf5_ble_srv_gls PUBLIC
+    nrf5_ble_gq
+  )
+endif()
+list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_GLS_DEPENDENCIES
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_racp
+  nrf5_ble_srv_gls
+  nrf5_config
+  nrf5_delay
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_GLS_DEPENDENCIES
+    nrf5_balloc
+    nrf5_balloc_fwd
+    nrf5_ble_gq
+    nrf5_cli_fwd
+    nrf5_ext_fprintf
+    nrf5_memobj
+    nrf5_memobj_fwd
+    nrf5_queue
+  )
+endif()
+
+# BLE Apple Notification Center Service
+add_library(nrf5_ble_srv_ancs_c OBJECT EXCLUDE_FROM_ALL
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_ancs_c/ancs_app_attr_get.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_ancs_c/ancs_attr_parser.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_ancs_c/nrf_ble_ancs_c.c"
+)
+target_include_directories(nrf5_ble_srv_ancs_c PUBLIC
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_ancs_c"
+)
+target_link_libraries(nrf5_ble_srv_ancs_c PUBLIC
+  nrf5_ble_db_discovery
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 15.3.0)
+  target_sources(nrf5_ble_srv_ancs_c PRIVATE
+    "${NRF5_SDK_PATH}/components/ble/ble_services/ble_ancs_c/ancs_tx_buffer.c"
+  )
+endif()
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  
+  target_link_libraries(nrf5_ble_srv_ancs_c PUBLIC
+    nrf5_ble_gq
+  )
+endif()
+list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_ANCS_C_DEPENDENCIES
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_balloc_fwd
+  nrf5_ble_common
+  nrf5_ble_db_discovery
+  nrf5_ble_srv_ancs_c
+  nrf5_cli
+  nrf5_cli_fwd
+  nrf5_config
+  nrf5_crc16
+  nrf5_delay
+  nrf5_ext_fprintf
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_log
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_memobj
+  nrf5_memobj_fwd
+  nrf5_mtx
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_pwr_mgmt
+  nrf5_queue
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_ANCS_C_DEPENDENCIES
+    nrf5_ble_gq
+  )
+endif()
+
+# BLE Object Transfer Service
+add_library(nrf5_ble_srv_ots OBJECT EXCLUDE_FROM_ALL
+  "${NRF5_SDK_PATH}/components/ble/ble_services/experimental_ble_ots/ble_ots.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/experimental_ble_ots/ble_ots_l2cap.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/experimental_ble_ots/ble_ots_oacp.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/experimental_ble_ots/ble_ots_object.c"
+)
+target_include_directories(nrf5_ble_srv_ots PUBLIC
+  "${NRF5_SDK_PATH}/components/ble/ble_services/experimental_ble_ots"
+)
+target_link_libraries(nrf5_ble_srv_ots PUBLIC
+  nrf5_ble_common
+  nrf5_crc32
+  nrf5_fds
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 15.3.0)
+  target_sources(nrf5_ble_srv_ots PRIVATE
+    "${NRF5_SDK_PATH}/components/ble/ble_services/experimental_ble_ots/ble_hvx_buffering.c"
+  )
+endif()
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  
+  target_link_libraries(nrf5_ble_srv_ots PUBLIC
+    nrf5_ble_gq
+  )
+endif()
+list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_OTS_DEPENDENCIES
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_srv_ots
+  nrf5_config
+  nrf5_crc16
+  nrf5_crc32
+  nrf5_delay
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_OTS_DEPENDENCIES
+    nrf5_balloc
+    nrf5_balloc_fwd
+    nrf5_ble_gq
+    nrf5_cli_fwd
+    nrf5_ext_fprintf
+    nrf5_memobj
+    nrf5_memobj_fwd
+    nrf5_queue
+  )
+endif()
+
+# BLE Continuous Glucose Monitoring Service
+add_library(nrf5_ble_srv_cgms OBJECT EXCLUDE_FROM_ALL
+  "${NRF5_SDK_PATH}/components/ble/ble_services/experimental_nrf_ble_cgms/cgms_db.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/experimental_nrf_ble_cgms/cgms_meas.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/experimental_nrf_ble_cgms/cgms_racp.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/experimental_nrf_ble_cgms/cgms_socp.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/experimental_nrf_ble_cgms/cgms_sst.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/experimental_nrf_ble_cgms/nrf_ble_cgms.c"
+)
+target_include_directories(nrf5_ble_srv_cgms PUBLIC
+  "${NRF5_SDK_PATH}/components/ble/ble_services/experimental_nrf_ble_cgms"
+)
+target_link_libraries(nrf5_ble_srv_cgms PUBLIC
+  nrf5_ble_common
+  nrf5_ble_racp
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  
+  target_link_libraries(nrf5_ble_srv_cgms PUBLIC
+    nrf5_ble_gq
+  )
+endif()
+list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_CGMS_DEPENDENCIES
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_ble_common
+  nrf5_ble_racp
+  nrf5_ble_srv_cgms
+  nrf5_config
+  nrf5_delay
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_sdh
+  nrf5_section
+  nrf5_soc
+  nrf5_strerror
+)
+if(NRF5_SDK_VERSION VERSION_EQUAL 16.0.0)
+  list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_CGMS_DEPENDENCIES
+    nrf5_balloc
+    nrf5_balloc_fwd
+    nrf5_ble_gq
+    nrf5_cli_fwd
+    nrf5_ext_fprintf
+    nrf5_memobj
+    nrf5_memobj_fwd
+    nrf5_queue
+  )
+endif()
+
+# BLE Eddystone library
+add_library(nrf5_ble_srv_eddystone OBJECT EXCLUDE_FROM_ALL
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_escs/nrf_ble_escs.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/eddystone/es_adv.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/eddystone/es_adv_frame.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/eddystone/es_adv_timing.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/eddystone/es_adv_timing_resolver.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/eddystone/es_battery_voltage_saadc.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/eddystone/es_flash.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/eddystone/es_gatts.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/eddystone/es_gatts_read.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/eddystone/es_gatts_write.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/eddystone/es_security.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/eddystone/es_slot.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/eddystone/es_slot_reg.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/eddystone/es_stopwatch.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/eddystone/es_tlm.c"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/eddystone/nrf_ble_es.c"
+)
+target_include_directories(nrf5_ble_srv_eddystone PUBLIC
+  "${NRF5_SDK_PATH}/components/ble/ble_services/ble_escs"
+  "${NRF5_SDK_PATH}/components/ble/ble_services/eddystone"
+)
+target_link_libraries(nrf5_ble_srv_eddystone PUBLIC
+  nrf5_app_scheduler
+  nrf5_ble_common
+  nrf5_crypto
+  nrf5_crypto_cifra_backend
+  nrf5_crypto_mbedtls_backend
+  nrf5_crypto_nrf_hw_backend
+  nrf5_crypto_oberon_backend
+  nrf5_drv_saadc
+  nrf5_fds
+)
+list(APPEND NRF5_LIBRARY_NRF5_BLE_SRV_EDDYSTONE_DEPENDENCIES
+  nrf5_app_scheduler
+  nrf5_app_timer
+  nrf5_app_util_platform
+  nrf5_atfifo
+  nrf5_atflags
+  nrf5_atomic
+  nrf5_balloc
+  nrf5_balloc_fwd
+  nrf5_ble_common
+  nrf5_ble_srv_eddystone
+  nrf5_cli
+  nrf5_cli_fwd
+  nrf5_config
+  nrf5_crc16
+  nrf5_crypto
+  nrf5_crypto_cifra_backend
+  nrf5_crypto_mbedtls_backend
+  nrf5_crypto_nrf_hw_backend
+  nrf5_crypto_oberon_backend
+  nrf5_delay
+  nrf5_drv_rng
+  nrf5_drv_saadc
+  nrf5_ext_cc310_bl_fwd
+  nrf5_ext_cc310_fwd
+  nrf5_ext_cifra_aes128_eax
+  nrf5_ext_cifra_aes128_eax_fwd
+  nrf5_ext_fprintf
+  nrf5_ext_mbedcrypto
+  nrf5_ext_mbedtls
+  nrf5_ext_mbedtls_fwd
+  nrf5_ext_mbedx509
+  nrf5_ext_micro_ecc_fwd
+  nrf5_ext_oberon_fwd
+  nrf5_ext_optiga_fwd
+  nrf5_fds
+  nrf5_fstorage
+  nrf5_log
+  nrf5_log_fwd
+  nrf5_mdk
+  nrf5_mem_manager
+  nrf5_memobj
+  nrf5_memobj_fwd
+  nrf5_mtx
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_nrfx_rng
+  nrf5_nrfx_saadc
+  nrf5_pwr_mgmt
+  nrf5_queue
+  nrf5_ringbuf
+  nrf5_sdh
+  nrf5_section
+  nrf5_sha256_fwd
+  nrf5_soc
+  nrf5_stack_info
   nrf5_strerror
 )

--- a/cmake/nrf5_log.cmake
+++ b/cmake/nrf5_log.cmake
@@ -105,6 +105,7 @@ list(APPEND NRF5_LIBRARY_NRF5_CLI_UART_DEPENDENCIES
   nrf5_mtx
   nrf5_nrfx_common
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_nrfx_uart
   nrf5_nrfx_uarte
   nrf5_pwr_mgmt
@@ -339,6 +340,7 @@ list(APPEND NRF5_LIBRARY_NRF5_LOG_BACKEND_UART_DEPENDENCIES
   nrf5_mtx
   nrf5_nrfx_common
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_nrfx_uart
   nrf5_nrfx_uarte
   nrf5_pwr_mgmt

--- a/cmake/nrf5_misc.cmake
+++ b/cmake/nrf5_misc.cmake
@@ -457,6 +457,7 @@ list(APPEND NRF5_LIBRARY_NRF5_BLOCK_DEV_SDC_DEPENDENCIES
   nrf5_mtx
   nrf5_nrfx_common
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_nrfx_spi
   nrf5_nrfx_spim
   nrf5_pwr_mgmt
@@ -552,6 +553,7 @@ list(APPEND NRF5_LIBRARY_NRF5_SERIAL_DEPENDENCIES
   nrf5_mtx
   nrf5_nrfx_common
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_nrfx_uart
   nrf5_nrfx_uarte
   nrf5_pwr_mgmt

--- a/cmake/nrf5_nrfx.cmake
+++ b/cmake/nrf5_nrfx.cmake
@@ -567,6 +567,7 @@ target_include_directories(nrf5_nrfx_uarte PUBLIC
 target_link_libraries(nrf5_nrfx_uarte PUBLIC
   nrf5_log
   nrf5_nrfx_common
+  nrf5_nrfx_prs
 )
 list(APPEND NRF5_LIBRARY_NRF5_NRFX_UARTE_DEPENDENCIES
   nrf5_app_scheduler
@@ -591,6 +592,7 @@ list(APPEND NRF5_LIBRARY_NRF5_NRFX_UARTE_DEPENDENCIES
   nrf5_mtx
   nrf5_nrfx_common
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_nrfx_uarte
   nrf5_pwr_mgmt
   nrf5_queue
@@ -611,6 +613,7 @@ target_include_directories(nrf5_nrfx_uart PUBLIC
 target_link_libraries(nrf5_nrfx_uart PUBLIC
   nrf5_log
   nrf5_nrfx_common
+  nrf5_nrfx_prs
 )
 list(APPEND NRF5_LIBRARY_NRF5_NRFX_UART_DEPENDENCIES
   nrf5_app_scheduler
@@ -635,6 +638,7 @@ list(APPEND NRF5_LIBRARY_NRF5_NRFX_UART_DEPENDENCIES
   nrf5_mtx
   nrf5_nrfx_common
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_nrfx_uart
   nrf5_pwr_mgmt
   nrf5_queue
@@ -680,6 +684,7 @@ list(APPEND NRF5_LIBRARY_NRF5_DRV_UART_DEPENDENCIES
   nrf5_mtx
   nrf5_nrfx_common
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_nrfx_uart
   nrf5_nrfx_uarte
   nrf5_pwr_mgmt
@@ -1584,6 +1589,7 @@ target_include_directories(nrf5_nrfx_comp PUBLIC
 target_link_libraries(nrf5_nrfx_comp PUBLIC
   nrf5_log
   nrf5_nrfx_common
+  nrf5_nrfx_prs
 )
 list(APPEND NRF5_LIBRARY_NRF5_NRFX_COMP_DEPENDENCIES
   nrf5_app_scheduler
@@ -1609,6 +1615,7 @@ list(APPEND NRF5_LIBRARY_NRF5_NRFX_COMP_DEPENDENCIES
   nrf5_nrfx_common
   nrf5_nrfx_comp
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_pwr_mgmt
   nrf5_queue
   nrf5_ringbuf
@@ -1651,6 +1658,7 @@ list(APPEND NRF5_LIBRARY_NRF5_DRV_COMP_DEPENDENCIES
   nrf5_nrfx_common
   nrf5_nrfx_comp
   nrf5_nrfx_hal
+  nrf5_nrfx_prs
   nrf5_pwr_mgmt
   nrf5_queue
   nrf5_ringbuf
@@ -1671,6 +1679,7 @@ target_include_directories(nrf5_nrfx_lpcomp PUBLIC
 target_link_libraries(nrf5_nrfx_lpcomp PUBLIC
   nrf5_log
   nrf5_nrfx_common
+  nrf5_nrfx_prs
 )
 list(APPEND NRF5_LIBRARY_NRF5_NRFX_LPCOMP_DEPENDENCIES
   nrf5_app_scheduler
@@ -1696,6 +1705,7 @@ list(APPEND NRF5_LIBRARY_NRF5_NRFX_LPCOMP_DEPENDENCIES
   nrf5_nrfx_common
   nrf5_nrfx_hal
   nrf5_nrfx_lpcomp
+  nrf5_nrfx_prs
   nrf5_pwr_mgmt
   nrf5_queue
   nrf5_ringbuf
@@ -1738,6 +1748,7 @@ list(APPEND NRF5_LIBRARY_NRF5_DRV_LPCOMP_DEPENDENCIES
   nrf5_nrfx_common
   nrf5_nrfx_hal
   nrf5_nrfx_lpcomp
+  nrf5_nrfx_prs
   nrf5_pwr_mgmt
   nrf5_queue
   nrf5_ringbuf


### PR DESCRIPTION
New examples:

* ble_app_ancs_c
* ble_app_eddystone
* ble_app_gls
* ble_app_proximity
* experimental/ble_app_cgms
* experimental/ble_app_ots

New libraries:
* nrf5_ble_racp
* nrf5_ble_srv_ias
* nrf5_ble_srv_tps
* nrf5_ble_srv_gls
* nrf5_ble_srv_ancs_c
* nrf5_ble_srv_ots
* nrf5_ble_srv_cgms
* nrf5_ble_srv_eddystone

Fixes problems with building and code generation of the existing libraries.