### PR TITLE
Add `nrf5_bsp_defs` lib with BSP-related definitions

### DIFF
--- a/ci/examples/peripheral/fatfs/CMakeLists.txt
+++ b/ci/examples/peripheral/fatfs/CMakeLists.txt
@@ -6,13 +6,11 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME}
   "${NRF5_SDK_PATH}/examples/peripheral/fatfs/main.c"
 )
-# This example requires only definitions from bsp.h file. Missing configuration
-# in sdk_config.h won't allow to compile bsp.c.
-target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
-  "${NRF5_SDK_PATH}/components/libraries/bsp"
-)
 
-add_definitions(-DBSP_DEFINES_ONLY -DCONFIG_GPIO_AS_PINRESET)
+add_compile_definitions(
+  BSP_DEFINES_ONLY
+  CONFIG_GPIO_AS_PINRESET
+)
 
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
@@ -45,6 +43,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
   nrf5_app_util_platform
   # BSP
   nrf5_boards
+  nrf5_bsp_defs
   # Misc
   nrf5_block_dev
   nrf5_block_dev_sdc

--- a/ci/examples/peripheral/pwm_library/CMakeLists.txt
+++ b/ci/examples/peripheral/pwm_library/CMakeLists.txt
@@ -6,13 +6,11 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME}
   "${NRF5_SDK_PATH}/examples/peripheral/pwm_library/main.c"
 )
-# This example requires only definitions from bsp.h file. Missing configuration
-# in sdk_config.h won't allow to compile bsp.c.
-target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
-  "${NRF5_SDK_PATH}/components/libraries/bsp"
-)
 
-add_definitions(-DBSP_DEFINES_ONLY -DCONFIG_GPIO_AS_PINRESET)
+add_compile_definitions(
+  BSP_DEFINES_ONLY
+  CONFIG_GPIO_AS_PINRESET
+)
 
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
@@ -29,4 +27,5 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
   nrf5_app_pwm
   # BSP
   nrf5_boards
+  nrf5_bsp_defs
 )

--- a/ci/examples/peripheral/qdec/CMakeLists.txt
+++ b/ci/examples/peripheral/qdec/CMakeLists.txt
@@ -7,13 +7,11 @@ add_executable(${CMAKE_PROJECT_NAME}
   "${NRF5_SDK_PATH}/examples/peripheral/qdec/main.c"
   "${NRF5_SDK_PATH}/examples/peripheral/qdec/qenc_sim.c"
 )
-# This example requires only definitions from bsp.h file. Missing configuration
-# in sdk_config.h won't allow to compile bsp.c.
-target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
-  "${NRF5_SDK_PATH}/components/libraries/bsp"
-)
 
-add_definitions(-DBSP_DEFINES_ONLY -DCONFIG_GPIO_AS_PINRESET)
+add_compile_definitions(
+  BSP_DEFINES_ONLY
+  CONFIG_GPIO_AS_PINRESET
+)
 
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
@@ -44,4 +42,5 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
   nrf5_app_util_platform
   # BSP
   nrf5_boards
+  nrf5_bsp_defs
 )

--- a/ci/examples/peripheral/temperature/CMakeLists.txt
+++ b/ci/examples/peripheral/temperature/CMakeLists.txt
@@ -6,13 +6,11 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME}
   "${NRF5_SDK_PATH}/examples/peripheral/temperature/main.c"
 )
-# This example requires only definitions from bsp.h file. Missing configuration
-# in sdk_config.h won't allow to compile bsp.c.
-target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
-  "${NRF5_SDK_PATH}/components/libraries/bsp"
-)
 
-add_definitions(-DBSP_DEFINES_ONLY -DCONFIG_GPIO_AS_PINRESET)
+add_compile_definitions(
+  BSP_DEFINES_ONLY
+  CONFIG_GPIO_AS_PINRESET
+)
 
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
@@ -40,4 +38,5 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
   nrf5_app_util_platform
   # BSP
   nrf5_boards
+  nrf5_bsp_defs
 )

--- a/ci/examples/peripheral/timer/CMakeLists.txt
+++ b/ci/examples/peripheral/timer/CMakeLists.txt
@@ -6,17 +6,16 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME}
   "${NRF5_SDK_PATH}/examples/peripheral/timer/main.c"
 )
-# This example requires only definitions from bsp.h file. Missing configuration
-# in sdk_config.h won't allow to compile bsp.c.
-target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
-  "${NRF5_SDK_PATH}/components/libraries/bsp"
-)
 
-add_definitions(-DBSP_DEFINES_ONLY -DCONFIG_GPIO_AS_PINRESET)
+add_compile_definitions(
+  BSP_DEFINES_ONLY
+  CONFIG_GPIO_AS_PINRESET
+)
 
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
   nrf5_boards
+  nrf5_bsp_defs
   nrf5_nrfx_timer
   nrf5_drv_timer
   nrf5_app_error

--- a/ci/examples/peripheral/uart/CMakeLists.txt
+++ b/ci/examples/peripheral/uart/CMakeLists.txt
@@ -6,13 +6,11 @@ include("nrf5")
 add_executable(${CMAKE_PROJECT_NAME}
   "${NRF5_SDK_PATH}/examples/peripheral/uart/main.c"
 )
-# This example requires only definitions from bsp.h file. Missing configuration
-# in sdk_config.h won't allow to compile bsp.c.
-target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
-  "${NRF5_SDK_PATH}/components/libraries/bsp"
-)
 
-add_definitions(-DBSP_DEFINES_ONLY -DCONFIG_GPIO_AS_PINRESET)
+add_compile_definitions(
+  BSP_DEFINES_ONLY
+  CONFIG_GPIO_AS_PINRESET
+)
 
 nrf5_target(${CMAKE_PROJECT_NAME})
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
@@ -27,4 +25,5 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE
   nrf5_app_uart
   # BSP
   nrf5_boards
+  nrf5_bsp_defs
 )

--- a/ci/libraries/nrf5_bsp.json
+++ b/ci/libraries/nrf5_bsp.json
@@ -19,6 +19,20 @@
       ]
     }
   },
+  "nrf5_bsp_defs": {
+    "documentation": "Board Support Package (definitions only)",
+    "variant": "interface",
+    "dependencies": {
+      "interface": [
+        "nrf5_boards"
+      ]
+    },
+    "includes": {
+      "interface": [
+        "components/libraries/bsp"
+      ]
+    }
+  },
   "nrf5_bsp": {
     "documentation": "Board Support Package",
     "variant": "object",

--- a/cmake/nrf5_bsp.cmake
+++ b/cmake/nrf5_bsp.cmake
@@ -44,6 +44,24 @@ list(APPEND NRF5_LIBRARY_NRF5_BOARDS_DEPENDENCIES
   nrf5_soc
 )
 
+# Board Support Package (definitions only)
+add_library(nrf5_bsp_defs INTERFACE)
+target_include_directories(nrf5_bsp_defs INTERFACE
+  "${NRF5_SDK_PATH}/components/libraries/bsp"
+)
+target_link_libraries(nrf5_bsp_defs INTERFACE
+  nrf5_boards
+)
+list(APPEND NRF5_LIBRARY_NRF5_BSP_DEFS_DEPENDENCIES
+  nrf5_boards
+  nrf5_bsp_defs
+  nrf5_config
+  nrf5_mdk
+  nrf5_nrfx_common
+  nrf5_nrfx_hal
+  nrf5_soc
+)
+
 # Board Support Package
 add_library(nrf5_bsp OBJECT EXCLUDE_FROM_ALL
   "${NRF5_SDK_PATH}/components/libraries/bsp/bsp.c"


### PR DESCRIPTION
Closes #42 

Added the above library and cleaned up examples from the 'peripheral' category: fatfs, pwm_library, qdec, temperature, timer, uart
