### PR TITLE
Add two STATUS messages

### DIFF
--- a/cmake/nrf5.cmake
+++ b/cmake/nrf5.cmake
@@ -201,6 +201,8 @@ endif()
 
 # Microcontroller Development Kit (MDK)
 nrf5_get_startup_file(${NRF5_SDK_PATH} ${NRF5_TARGET} out_startup_file out_system_file)
+message(STATUS "Using startup file: ${out_startup_file}")
+message(STATUS "Using system file: ${out_system_file}")
 
 add_library(nrf5_mdk OBJECT EXCLUDE_FROM_ALL
   "${out_startup_file}"


### PR DESCRIPTION
This commit adds two messages
* Name of startup file being used (with file path)
* Name of system file being used (with file path)

This may for example look like this:

```
Using startup file: /home/gudni/Downloads/nRF5_SDK_17.0.2_d674dde/modules/nrfx/mdk/gcc_startup_nrf52.S
Using system file: /home/gudni/Downloads/nRF5_SDK_17.0.2_d674dde/modules/nrfx/mdk/system_nrf52.c
```